### PR TITLE
Restore basePath and upload inner build directory for GitHub Pages

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -35,10 +35,15 @@ jobs:
         working-directory: docs
         run: npx zudoku build
 
+      - name: Prepare deployment
+        run: |
+          cp docs/dist/404.html docs/dist/space-gass-api/404.html 2>/dev/null || true
+          touch docs/dist/space-gass-api/.nojekyll
+
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v4
         with:
-          path: docs/dist
+          path: docs/dist/space-gass-api
           include-hidden-files: true
 
   deploy:

--- a/docs/zudoku.config.tsx
+++ b/docs/zudoku.config.tsx
@@ -118,6 +118,7 @@ function generateCodeSnippet({ selectedLang, operation }: any): string | false {
 // --- Zudoku config ---
 
 const config: ZudokuConfig = {
+  basePath: "/space-gass-api",
   site: {
     title: "SpaceGass API",
     logo: {


### PR DESCRIPTION
basePath is needed so Zudoku generates correct /space-gass-api/ prefixed links and asset paths. Uploading docs/dist/space-gass-api (the inner directory) as the artifact root avoids the double-nesting issue.