### PR TITLE
Update all documentation pages for current API state

### DIFF
--- a/docs/pages/getting-started/authentication.mdx
+++ b/docs/pages/getting-started/authentication.mdx
@@ -1,69 +1,54 @@
 ---
 title: Authentication
-description: API key authentication for the SpaceGass API
+description: Authentication for the SpaceGass API
 ---
 
-The SpaceGass API uses API key authentication. Every request must
-include a valid key in the `X-API-KEY` HTTP header.
+The SPACE GASS API currently requires **no authentication**. The API
+runs as a local service on your machine and is accessed over plain
+HTTP — no API keys, tokens, or credentials are needed.
 
-## Setting Up Authentication
+## Default Connection
 
-<CodeTabs>
+The SDK clients connect to the local API with no setup:
+
 ```csharp title="C#"
-using Microsoft.Kiota.Abstractions.Authentication;
-using Microsoft.Kiota.Http.HttpClientLibrary;
-using SpaceGassApi.Client;
+using SpaceGassApi;
 
-// Kiota has a built-in provider for API key auth
-var authProvider = new ApiKeyAuthenticationProvider(
-    "YOUR_API_KEY",
-    "X-API-KEY",
-    ApiKeyAuthenticationProvider.KeyLocation.Header);
-
-var adapter = new HttpClientRequestAdapter(authProvider);
-adapter.BaseUrl = "https://localhost:5001";
-
-var client = new SpaceGassApiClient(adapter);
+var client = SpaceGassApiClient.CreateClient();
+// Connects to http://localhost:53483/api/v1
 ```
 
 ```python title="Python"
-# Configure the request adapter with your API key
-# The key is sent as the X-API-KEY header on every request
-adapter.base_url = "https://localhost:5001"
+from extensions.client_extensions import create_client
+
+client = create_client()
+# Connects to http://localhost:53483/api/v1
 ```
 
 ```bash title="curl"
-# Pass the API key as a header
-curl -H "X-API-KEY: YOUR_API_KEY" \
-  https://localhost:5001/api/v1/info
+curl http://localhost:53483/api/v1/service/info
 ```
-</CodeTabs>
 
-## Validating Your Key
+## Custom Base URL
 
-You can check whether a key is valid before making other API calls:
+If the API is running on a different port, pass the URL explicitly:
 
-<CodeTabs>
 ```csharp title="C#"
-var result = await client.Apikey.Validate.PostAsync();
-// Returns ApiKeyValidationResponse with IsValid, Tier, ExpiresAt
+var client = SpaceGassApiClient.CreateClient("http://localhost:8080/api/v1");
 ```
 
-```bash title="curl"
-curl -X POST https://localhost:5001/api/v1/apikey/validate \
-  -H "X-API-KEY: YOUR_API_KEY"
+```python title="Python"
+client = create_client("http://localhost:8080/api/v1")
 ```
-</CodeTabs>
 
-## Error Responses
+## Future Authentication
 
-| Status | Meaning |
-|--------|---------|
-| `401`  | API key is missing, invalid, or expired |
-| `403`  | API key does not have permission for this operation |
+API key authentication may be introduced in a future release. When
+this happens, the SDK will support it as an optional parameter:
 
-{/* TODO: Adapt additional detail from docs/API_KEY_SYSTEM.md */}
-{/* Topics to cover: */}
-{/* - API key format and structure */}
-{/* - Tier-based rate limits */}
-{/* - Key generation and deactivation endpoints */}
+```csharp title="C# (future)"
+var client = SpaceGassApiClient.CreateClient(apiKey: "your-key-here");
+```
+
+Existing code using the parameterless `CreateClient()` will continue
+to work — adding authentication will be a non-breaking change.

--- a/docs/pages/getting-started/introduction.mdx
+++ b/docs/pages/getting-started/introduction.mdx
@@ -34,15 +34,16 @@ All API endpoints are served under a versioned path:
 
 ## Authentication
 
-Every request must include an API key in the `X-API-KEY` header.
-See [Authentication](/getting-started/authentication) for details.
+No authentication is required. The API runs locally on your machine
+and is accessed over plain HTTP. See
+[Authentication](/getting-started/authentication) for details.
 
 ## SDK Clients
 
 Generated SDK clients are available for:
 
-- **C#** — `SpaceGassApi.Client` (NuGet package / project reference)
-- **Python** — `spacegass-api-client` (pip installable)
+- **C#** — `SpaceGassApi` (NuGet package)
+- **Python** — `space-gass-api` (pip installable)
 
 Both are generated from the OpenAPI specification using
 [Microsoft Kiota](https://learn.microsoft.com/en-us/openapi/kiota/overview).
@@ -51,8 +52,6 @@ Both are generated from the OpenAPI specification using
 
 - [Quick Start](/getting-started/quick-start) — Get up and running
   in 5 minutes
-- [Authentication](/getting-started/authentication) — Set up your
-  API key
 - [SDK Examples](/guides/sdk-examples) — Full walkthrough using the
   C# and Python clients
 - [API Reference](/api) — Browse all endpoints interactively

--- a/docs/pages/getting-started/quick-start.mdx
+++ b/docs/pages/getting-started/quick-start.mdx
@@ -9,7 +9,6 @@ file, and reading nodes — using the SDK clients or plain HTTP.
 ### Prerequisites
 
 - [SPACE GASS](https://www.spacegass.com/) installed on your machine
-- A valid API key
 - An existing `.sg` project file on disk
 
 <Stepper>
@@ -25,11 +24,11 @@ file, and reading nodes — using the SDK clients or plain HTTP.
    "C:\Program Files\SPACE GASS 14.25\SpaceGassApi.exe"
    ```
 
-   By default the service starts on `https://localhost:5001`. To use a
+   By default the service starts on `http://localhost:53483`. To use a
    different port, pass the `--urls` flag:
 
    ```bash
-   "C:\Program Files\SPACE GASS 14.25\SpaceGassApi.exe" --urls="https://localhost:8443"
+   "C:\Program Files\SPACE GASS 14.25\SpaceGassApi.exe" --urls="http://localhost:8080"
    ```
 
    Leave the terminal or shortcut window open — the service runs until
@@ -38,29 +37,19 @@ file, and reading nodes — using the SDK clients or plain HTTP.
 1. **Install the SDK**
 
    The API includes generated SDK clients for C# and Python. These
-   handle authentication, serialisation, and give you typed methods
-   for every endpoint. If you prefer raw HTTP requests, you can skip
-   this step and use curl or any HTTP client.
+   handle serialisation and give you typed methods for every endpoint.
+   If you prefer raw HTTP requests, you can skip this step and use
+   curl or any HTTP client.
 
    <CodeTabs>
    ```csharp title="C#"
    // From your project directory, add the NuGet package:
-   dotnet add package SpaceGassApi.Client
-
-   // This also installs the required Kiota dependencies:
-   //   Microsoft.Kiota.Abstractions
-   //   Microsoft.Kiota.Http.HttpClientLibrary
-   //   Microsoft.Kiota.Serialization.Json
+   dotnet add package SpaceGassApi
    ```
 
    ```python title="Python"
    # Install from PyPI:
-   pip install spacegass-api-client
-
-   # This also installs the required Kiota dependencies:
-   #   microsoft-kiota-abstractions
-   #   microsoft-kiota-http
-   #   microsoft-kiota-serialization-json
+   pip install space-gass-api
    ```
 
    ```bash title="curl"
@@ -73,34 +62,20 @@ file, and reading nodes — using the SDK clients or plain HTTP.
 
    <CodeTabs>
    ```csharp title="C#"
-   using Microsoft.Kiota.Abstractions.Authentication;
-   using Microsoft.Kiota.Http.HttpClientLibrary;
-   using SpaceGassApi.Client;
+   using SpaceGassApi;
 
-   var authProvider = new ApiKeyAuthenticationProvider(
-       "YOUR_API_KEY",
-       "X-API-KEY",
-       ApiKeyAuthenticationProvider.KeyLocation.Header);
-
-   var adapter = new HttpClientRequestAdapter(authProvider);
-   adapter.BaseUrl = "https://localhost:5001";
-
-   var client = new SpaceGassApiClient(adapter);
+   var client = SpaceGassApiClient.CreateClient();
    ```
 
    ```python title="Python"
-   from microsoft_kiota_http.httpx_request_adapter import HttpxRequestAdapter
-   from spacegass_client.space_gass_api_client import SpaceGassApiClient
+   from extensions.client_extensions import create_client
 
-   adapter = HttpxRequestAdapter(auth_provider)
-   adapter.base_url = "https://localhost:5001"
-
-   client = SpaceGassApiClient(adapter)
+   client = create_client()
    ```
 
    ```bash title="curl"
-   # Include the API key header with every request:
-   curl -H "X-API-KEY: YOUR_API_KEY" https://localhost:5001/api/v1/...
+   # No client setup needed — just make HTTP requests directly.
+   curl http://localhost:53483/api/v1/service/info
    ```
    </CodeTabs>
 
@@ -108,22 +83,21 @@ file, and reading nodes — using the SDK clients or plain HTTP.
 
    <CodeTabs>
    ```csharp title="C#"
-   using SpaceGassApi.Client.Models;
+   using SpaceGassApi.Models;
 
-   await client.Job.File.Open.PostAsync(
-       new LocalFileRequest { FilePath = @"C:\Projects\MyStructure.sg" });
+   await client.Job.Open.PostAsync(
+       new OpenJobRequest { FilePath = @"C:\Projects\MyStructure.sg" });
    ```
 
    ```python title="Python"
-   from spacegass_client.models.local_file_request import LocalFileRequest
+   from space_gass_api.models.open_job_request import OpenJobRequest
 
-   await client.job.file.open.post(
-       LocalFileRequest(file_path="C:\\Projects\\MyStructure.sg"))
+   await client.job.open.post(
+       OpenJobRequest(file_path="C:\\Projects\\MyStructure.sg"))
    ```
 
    ```bash title="curl"
-   curl -X POST https://localhost:5001/api/v1/job/file/open \
-     -H "X-API-KEY: YOUR_API_KEY" \
+   curl -X POST http://localhost:53483/api/v1/job/open \
      -H "Content-Type: application/json" \
      -d '{"filePath": "C:\\Projects\\MyStructure.sg"}'
    ```
@@ -149,8 +123,7 @@ file, and reading nodes — using the SDK clients or plain HTTP.
    ```
 
    ```bash title="curl"
-   curl https://localhost:5001/api/v1/job/structure/nodes \
-     -H "X-API-KEY: YOUR_API_KEY"
+   curl http://localhost:53483/api/v1/job/structure/nodes
    ```
    </CodeTabs>
 
@@ -166,16 +139,13 @@ file, and reading nodes — using the SDK clients or plain HTTP.
    ```
 
    ```bash title="curl"
-   curl -X POST https://localhost:5001/api/v1/job/close \
-     -H "X-API-KEY: YOUR_API_KEY"
+   curl -X POST http://localhost:53483/api/v1/job/close
    ```
    </CodeTabs>
 </Stepper>
 
 ## Next Steps
 
-- [Authentication](/getting-started/authentication) — API key details
-  and setup
 - [SDK Examples](/guides/sdk-examples) — Full walkthrough with error
   handling
 - [File Handling](/guides/file-handling) — Open, save, force-open, and

--- a/docs/pages/guides/error-handling.mdx
+++ b/docs/pages/guides/error-handling.mdx
@@ -25,7 +25,6 @@ information.
 | Status | Meaning |
 |--------|---------|
 | `400`  | Bad request — validation failure or invalid input |
-| `401`  | Unauthorized — missing or invalid API key |
 | `404`  | Not found — resource does not exist |
 | `409`  | Conflict — operation conflicts with current state (e.g., file locked) |
 | `500`  | Server error — unexpected internal failure |
@@ -44,10 +43,6 @@ catch (ApiException ex) when (ex.ResponseStatusCode == 404)
 {
     Console.WriteLine($"Node not found: {ex.Message}");
 }
-catch (ApiException ex) when (ex.ResponseStatusCode == 401)
-{
-    Console.WriteLine("Invalid API key. Check your X-API-KEY header.");
-}
 catch (ApiException ex)
 {
     Console.WriteLine($"API error {ex.ResponseStatusCode}: {ex.Message}");
@@ -62,23 +57,15 @@ try:
 except APIError as e:
     if e.response_status_code == 404:
         print(f"Node not found: {e.message}")
-    elif e.response_status_code == 401:
-        print("Invalid API key.")
     else:
         print(f"API error {e.response_status_code}: {e.message}")
 ```
 
 ```bash title="curl"
 # curl shows HTTP status in verbose mode
-curl -v https://localhost:5001/api/v1/job/structure/nodes/999 \
-  -H "X-API-KEY: YOUR_API_KEY"
+curl -v http://localhost:53483/api/v1/job/structure/nodes/999
 
 # Response (404):
 # {"type":"...","title":"Not Found","status":404,"detail":"Node 999 not found"}
 ```
 </CodeTabs>
-
-{/* TODO: Adapt additional content from docs/ERROR_HANDLING.md */}
-{/* Topics to cover: */}
-{/* - Validation error details (field-level errors) */}
-{/* - Common error scenarios and resolutions */}

--- a/docs/pages/guides/file-handling.mdx
+++ b/docs/pages/guides/file-handling.mdx
@@ -10,25 +10,24 @@ The API provides endpoints for managing SPACE GASS `.sg` project files
 
 <CodeTabs>
 ```csharp title="C#"
-using SpaceGassApi.Client.Models;
+using SpaceGassApi.Models;
 
-await client.Job.File.Open.PostAsync(
-    new LocalFileRequest
+await client.Job.Open.PostAsync(
+    new OpenJobRequest
     {
         FilePath = @"C:\Projects\MyStructure.sg"
     });
 ```
 
 ```python title="Python"
-from spacegass_client.models.local_file_request import LocalFileRequest
+from space_gass_api.models.open_job_request import OpenJobRequest
 
-await client.job.file.open.post(
-    LocalFileRequest(file_path="C:\\Projects\\MyStructure.sg"))
+await client.job.open.post(
+    OpenJobRequest(file_path="C:\\Projects\\MyStructure.sg"))
 ```
 
 ```bash title="curl"
-curl -X POST https://localhost:5001/api/v1/job/file/open \
-  -H "X-API-KEY: YOUR_API_KEY" \
+curl -X POST http://localhost:53483/api/v1/job/open \
   -H "Content-Type: application/json" \
   -d '{"filePath": "C:\\Projects\\MyStructure.sg"}'
 ```
@@ -41,8 +40,8 @@ is locked by another process or has unsaved changes:
 
 <CodeTabs>
 ```csharp title="C#"
-var status = await client.Job.File.Status.PostAsync(
-    new LocalFileRequest
+var status = await client.File.Status.PostAsync(
+    new FileStatusRequest
     {
         FilePath = @"C:\Projects\MyStructure.sg"
     });
@@ -51,8 +50,7 @@ var status = await client.Job.File.Status.PostAsync(
 ```
 
 ```bash title="curl"
-curl -X POST https://localhost:5001/api/v1/job/file/status \
-  -H "X-API-KEY: YOUR_API_KEY" \
+curl -X POST http://localhost:53483/api/v1/file/status \
   -H "Content-Type: application/json" \
   -d '{"filePath": "C:\\Projects\\MyStructure.sg"}'
 ```
@@ -60,27 +58,41 @@ curl -X POST https://localhost:5001/api/v1/job/file/status \
 
 ## Saving
 
+The save endpoint handles both saving to the current path and
+saving to a new path. Pass a `filePath` to save as a new file,
+or omit it to save in place.
+
 <CodeTabs>
 ```csharp title="C#"
-// Save an already-opened file
-await client.Job.File.Save.PostAsync();
+// Save to current file
+await client.Job.Save.PostAsync(new SaveJobRequest());
 
-// Save as a new file path
-await client.Job.File.SaveAs.PostAsync(
-    new LocalFileRequest
+// Save to a new file path
+await client.Job.Save.PostAsync(
+    new SaveJobRequest
     {
         FilePath = @"C:\Projects\MyStructure_Copy.sg"
     });
 ```
 
-```bash title="curl"
-# Save current file
-curl -X POST https://localhost:5001/api/v1/job/file/save \
-  -H "X-API-KEY: YOUR_API_KEY"
+```python title="Python"
+from space_gass_api.models.save_job_request import SaveJobRequest
 
-# Save as new file
-curl -X POST https://localhost:5001/api/v1/job/file/save-as \
-  -H "X-API-KEY: YOUR_API_KEY" \
+# Save to current file
+await client.job.save.post(SaveJobRequest())
+
+# Save to a new file path
+await client.job.save.post(
+    SaveJobRequest(file_path="C:\\Projects\\MyStructure_Copy.sg"))
+```
+
+```bash title="curl"
+# Save to current file
+curl -X POST http://localhost:53483/api/v1/job/save \
+  -H "Content-Type: application/json"
+
+# Save to a new file path
+curl -X POST http://localhost:53483/api/v1/job/save \
   -H "Content-Type: application/json" \
   -d '{"filePath": "C:\\Projects\\MyStructure_Copy.sg"}'
 ```
@@ -90,12 +102,15 @@ curl -X POST https://localhost:5001/api/v1/job/file/save-as \
 
 <CodeTabs>
 ```csharp title="C#"
-await client.Job.File.New.PostAsync();
+await client.Job.New.PostAsync(new NewPostRequestBody());
+```
+
+```python title="Python"
+await client.job.new.post()
 ```
 
 ```bash title="curl"
-curl -X POST https://localhost:5001/api/v1/job/file/new \
-  -H "X-API-KEY: YOUR_API_KEY"
+curl -X POST http://localhost:53483/api/v1/job/new
 ```
 </CodeTabs>
 
@@ -111,13 +126,6 @@ await client.job.close.post()
 ```
 
 ```bash title="curl"
-curl -X POST https://localhost:5001/api/v1/job/close \
-  -H "X-API-KEY: YOUR_API_KEY"
+curl -X POST http://localhost:53483/api/v1/job/close
 ```
 </CodeTabs>
-
-{/* TODO: Adapt additional content from docs/SPACE_GASS_FILE_HANDLING.md */}
-{/* Topics to cover: */}
-{/* - Force open scenarios (locked files, unsaved changes) */}
-{/* - File status enum values and their meanings */}
-{/* - Recommended workflow: status check -> open -> modify -> save -> close */}

--- a/docs/pages/guides/sdk-examples.mdx
+++ b/docs/pages/guides/sdk-examples.mdx
@@ -11,27 +11,17 @@ and close the project — with proper error handling.
 
 <CodeTabs>
 ```csharp title="C#"
-using Microsoft.Kiota.Abstractions.Authentication;
-using Microsoft.Kiota.Http.HttpClientLibrary;
-using SpaceGassApi.Client;
-using SpaceGassApi.Client.Models;
+using SpaceGassApi;
+using SpaceGassApi.Models;
 
-// 1. Set up authentication
-var authProvider = new ApiKeyAuthenticationProvider(
-    "YOUR_API_KEY",
-    "X-API-KEY",
-    ApiKeyAuthenticationProvider.KeyLocation.Header);
-
-var adapter = new HttpClientRequestAdapter(authProvider);
-adapter.BaseUrl = "https://localhost:5001";
-
-var client = new SpaceGassApiClient(adapter);
+// 1. Create the client
+var client = SpaceGassApiClient.CreateClient();
 
 try
 {
     // 2. Open a project file
-    await client.Job.File.Open.PostAsync(
-        new LocalFileRequest
+    await client.Job.Open.PostAsync(
+        new OpenJobRequest
         {
             FilePath = @"C:\Projects\MyStructure.sg"
         });
@@ -61,16 +51,16 @@ catch (Exception ex)
 ```
 
 ```python title="Python"
-from spacegass_client.space_gass_api_client import SpaceGassApiClient
-from spacegass_client.models.local_file_request import LocalFileRequest
+from extensions.client_extensions import create_client
+from space_gass_api.models.open_job_request import OpenJobRequest
 
-# 1. Set up authentication (adapter configured with API key)
-client = SpaceGassApiClient(adapter)
+# 1. Create the client
+client = create_client()
 
 try:
     # 2. Open a project file
-    await client.job.file.open.post(
-        LocalFileRequest(file_path="C:\\Projects\\MyStructure.sg"))
+    await client.job.open.post(
+        OpenJobRequest(file_path="C:\\Projects\\MyStructure.sg"))
 
     # 3. Get job information
     job = await client.job.get()
@@ -107,8 +97,7 @@ print(f"Node {node.key}: ({node.x}, {node.y}, {node.z})")
 ```
 
 ```bash title="curl"
-curl https://localhost:5001/api/v1/job/structure/nodes/1 \
-  -H "X-API-KEY: YOUR_API_KEY"
+curl http://localhost:53483/api/v1/job/structure/nodes/1
 ```
 </CodeTabs>
 
@@ -136,8 +125,7 @@ filtered = await client.job.structure.nodes.get(
 ```
 
 ```bash title="curl"
-curl "https://localhost:5001/api/v1/job/structure/nodes?MinX=0&MaxX=100&Limit=50" \
-  -H "X-API-KEY: YOUR_API_KEY"
+curl "http://localhost:53483/api/v1/job/structure/nodes?MinX=0&MaxX=100&Limit=50"
 ```
 </CodeTabs>
 
@@ -156,7 +144,7 @@ Console.WriteLine($"Created node {newNode.Key}");
 ```
 
 ```python title="Python"
-from spacegass_client.models.node_create import NodeCreate
+from space_gass_api.models.node_create import NodeCreate
 
 new_node = await client.job.structure.nodes.post(
     NodeCreate(x=10.0, y=20.0, z=0.0))
@@ -164,8 +152,7 @@ print(f"Created node {new_node.key}")
 ```
 
 ```bash title="curl"
-curl -X POST https://localhost:5001/api/v1/job/structure/nodes \
-  -H "X-API-KEY: YOUR_API_KEY" \
+curl -X POST http://localhost:53483/api/v1/job/structure/nodes \
   -H "Content-Type: application/json" \
   -d '{"x": 10.0, "y": 20.0, "z": 0.0}'
 ```
@@ -201,8 +188,7 @@ for r in result.results:
 ```
 
 ```bash title="curl"
-curl https://localhost:5001/api/v1/job/query/analysis/static/node/reactions \
-  -H "X-API-KEY: YOUR_API_KEY"
+curl http://localhost:53483/api/v1/job/query/analysis/static/node/reactions
 ```
 </CodeTabs>
 
@@ -230,8 +216,7 @@ result = await client.job.query.analysis.static.node.displacements.get(
 ```
 
 ```bash title="curl"
-curl "https://localhost:5001/api/v1/job/query/analysis/static/node/displacements?case=1&case=3&node=10&node=11&node=12" \
-  -H "X-API-KEY: YOUR_API_KEY"
+curl "http://localhost:53483/api/v1/job/query/analysis/static/node/displacements?case=1&case=3&node=10&node=11&node=12"
 ```
 </CodeTabs>
 
@@ -273,8 +258,7 @@ for m in result.results:
 ```
 
 ```bash title="curl"
-curl "https://localhost:5001/api/v1/job/query/analysis/static/member/intermediate-forces?member=1" \
-  -H "X-API-KEY: YOUR_API_KEY"
+curl "http://localhost:53483/api/v1/job/query/analysis/static/member/intermediate-forces?member=1"
 ```
 </CodeTabs>
 
@@ -300,8 +284,7 @@ for b in result.results:
 ```
 
 ```bash title="curl"
-curl https://localhost:5001/api/v1/job/query/analysis/buckling/load-factors \
-  -H "X-API-KEY: YOUR_API_KEY"
+curl http://localhost:53483/api/v1/job/query/analysis/buckling/load-factors
 ```
 </CodeTabs>
 
@@ -328,8 +311,7 @@ for f in result.results:
 ```
 
 ```bash title="curl"
-curl https://localhost:5001/api/v1/job/query/analysis/dynamic/natural-frequencies \
-  -H "X-API-KEY: YOUR_API_KEY"
+curl http://localhost:53483/api/v1/job/query/analysis/dynamic/natural-frequencies
 ```
 </CodeTabs>
 
@@ -355,8 +337,7 @@ for s in result.results:
 ```
 
 ```bash title="curl"
-curl https://localhost:5001/api/v1/job/query/design/steel-member/check-summary \
-  -H "X-API-KEY: YOUR_API_KEY"
+curl http://localhost:53483/api/v1/job/query/design/steel-member/check-summary
 ```
 </CodeTabs>
 
@@ -399,30 +380,9 @@ page2 = await client.job.query.analysis.static.node.displacements.get(
 
 ```bash title="curl"
 # Page 1
-curl "https://localhost:5001/api/v1/job/query/analysis/static/node/displacements?offset=0&limit=100" \
-  -H "X-API-KEY: YOUR_API_KEY"
+curl "http://localhost:53483/api/v1/job/query/analysis/static/node/displacements?offset=0&limit=100"
 
 # Page 2
-curl "https://localhost:5001/api/v1/job/query/analysis/static/node/displacements?offset=100&limit=100" \
-  -H "X-API-KEY: YOUR_API_KEY"
+curl "http://localhost:53483/api/v1/job/query/analysis/static/node/displacements?offset=100&limit=100"
 ```
 </CodeTabs>
-
-## Self-Signed Certificates (Development)
-
-When running the API locally with a self-signed SSL certificate,
-you may need to bypass certificate validation:
-
-```csharp title="C#"
-var handler = new HttpClientHandler
-{
-    ServerCertificateCustomValidationCallback =
-        HttpClientHandler.DangerousAcceptAnyServerCertificateValidator
-};
-var httpClient = new HttpClient(handler);
-var adapter = new HttpClientRequestAdapter(authProvider,
-    httpClient: httpClient);
-```
-
-> **Warning:** Only use this in development. Never disable certificate
-> validation in production.

--- a/docs/pages/guides/versioning.mdx
+++ b/docs/pages/guides/versioning.mdx
@@ -9,32 +9,15 @@ is part of the URL path.
 ## URL Format
 
 ```
-https://your-host/api/v{version}/{resource}
+http://your-host/api/v{version}/{resource}
 ```
 
 All current endpoints use **v1**:
 
 ```
-https://localhost:5001/api/v1/job
-https://localhost:5001/api/v1/job/structure/nodes
-https://localhost:5001/api/v1/libraries/sections
-```
-
-## Version Header
-
-As an alternative to URL versioning, you can specify the version
-via the `X-API-VERSION` header. If both are present, the URL segment
-takes priority.
-
-```bash title="curl"
-# Version in URL (preferred)
-curl https://localhost:5001/api/v1/job \
-  -H "X-API-KEY: YOUR_API_KEY"
-
-# Version in header (alternative)
-curl https://localhost:5001/api/job \
-  -H "X-API-KEY: YOUR_API_KEY" \
-  -H "X-API-VERSION: 1"
+http://localhost:53483/api/v1/job
+http://localhost:53483/api/v1/job/structure/nodes
+http://localhost:53483/api/v1/job/structure/members
 ```
 
 ## SDK Clients
@@ -54,7 +37,12 @@ nodes = await client.job.structure.nodes.get()
 ```
 </CodeTabs>
 
-{/* TODO: Adapt additional content from docs/VERSIONING.md */}
-{/* Topics to cover: */}
-{/* - Breaking vs non-breaking change policy */}
-{/* - Deprecation timeline */}
+## Package Versioning
+
+SDK and package versions mirror the SPACE GASS Desktop version to
+eliminate ambiguity:
+
+| SPACE GASS Desktop | NuGet Package | PyPI Package |
+|---|---|---|
+| v15.0.2 | `SpaceGassApi 15.0.2` | `space-gass-api==15.0.2` |
+| v15.1.0 | `SpaceGassApi 15.1.0` | `space-gass-api==15.1.0` |


### PR DESCRIPTION
- Removed API key auth references (no auth required)
- Updated all URLs: https://localhost:5001 → http://localhost:53483
- Replaced adapter boilerplate with CreateClient() one-liner
- Updated API paths: Job.File.* → Job.*, LocalFileRequest → OpenJobRequest/SaveJobRequest
- Updated package names: SpaceGassApi.Client → SpaceGassApi, spacegass_client → space_gass_api
- Removed 401/403 error codes from error handling guide
- Rewrote authentication page as "no auth needed" with future API key note
- Added package versioning table to versioning guide