### PR TITLE
Move GitHub and spacegass.com links to header icons next to theme toggle

### DIFF
--- a/docs/zudoku.config.tsx
+++ b/docs/zudoku.config.tsx
@@ -237,21 +237,37 @@ const config: ZudokuConfig = {
       to: "/api",
       icon: "code",
     },
-    {
-      type: "link",
-      label: "GitHub",
-      to: "https://github.com/Spacegass/space-gass-api",
-      target: "_blank",
-      icon: "github",
-    },
-    {
-      type: "link",
-      label: "spacegass.com",
-      to: "https://www.spacegass.com",
-      target: "_blank",
-      icon: "globe",
-    },
   ],
+  slots: {
+    "head-navigation-end": (
+      <div style={{ display: "flex", alignItems: "center", gap: "4px" }}>
+        <a
+          href="https://github.com/Spacegass/space-gass-api"
+          target="_blank"
+          rel="noopener noreferrer"
+          title="GitHub"
+          style={{ padding: "6px", display: "flex", opacity: 0.7 }}
+        >
+          <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
+            <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/>
+          </svg>
+        </a>
+        <a
+          href="https://www.spacegass.com"
+          target="_blank"
+          rel="noopener noreferrer"
+          title="spacegass.com"
+          style={{ padding: "6px", display: "flex", opacity: 0.7 }}
+        >
+          <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <circle cx="12" cy="12" r="10"></circle>
+            <path d="M12 2a14.5 14.5 0 0 0 0 20 14.5 14.5 0 0 0 0-20"></path>
+            <path d="M2 12h20"></path>
+          </svg>
+        </a>
+      </div>
+    ),
+  },
   defaults: {
     apis: {
       expandAllTags: false,


### PR DESCRIPTION
Replaced navigation bar links with icon buttons injected via the head-navigation-end slot, rendering next to the light/dark toggle.