### PR TITLE
sync: migrate self-weight POST to bare collection (14.50.71)

### DIFF
--- a/docs/pages/guides/examples/simple-beam.mdx
+++ b/docs/pages/guides/examples/simple-beam.mdx
@@ -330,18 +330,19 @@ print(f"Load cases: SW={self_weight_case.id}, G={dead_case.id}, Q={live_case.id}
 
 ## Step 8 — Apply the Self-Weight Load
 
-Attach a self-weight load to the self-weight case. POSTing a
-`SelfWeightLoadCreate` to `Job.Loads.SelfWeightLoads[caseId]` is keyed
-by load case Id (the case must already exist), and one self-weight
+Attach a self-weight load to the self-weight case. POST a
+`SelfWeightLoadCreate` to `Job.Loads.SelfWeightLoads` with `Case` set
+on the body — the load case must already exist, and one self-weight
 load per case is allowed. Acceleration is expressed in **G** (multiples
 of gravity), so set `AccelerationY = -1.0` for one G of gravity
 in the negative-Y direction.
 
 <CodeTabs>
 ```csharp title="C#"
-await client.Job.Loads.SelfWeightLoads[selfWeightCase.Id.Value].PostAsync(
+await client.Job.Loads.SelfWeightLoads.PostAsync(
     new SelfWeightLoadCreate
     {
+        Case = selfWeightCase.Id,
         AccelerationX = 0.0,
         AccelerationY = -1.0,    // 1 G downward
         AccelerationZ = 0.0,
@@ -349,8 +350,9 @@ await client.Job.Loads.SelfWeightLoads[selfWeightCase.Id.Value].PostAsync(
 ```
 
 ```python title="Python"
-await client.job.loads.self_weight_loads.by_case_id(self_weight_case.id).post(
+await client.job.loads.self_weight_loads.post(
     SelfWeightLoadCreate(
+        case=self_weight_case.id,
         acceleration_x=0.0,
         acceleration_y=-1.0,    # 1 G downward
         acceleration_z=0.0,

--- a/docs/zudoku.config.tsx
+++ b/docs/zudoku.config.tsx
@@ -33,6 +33,7 @@ const BODY_TYPE_OVERRIDES: Record<string, string> = {
   "POST /job/structure/materials/library": "MaterialLibraryCreate",
   "POST /job/loads/combination-load-cases": "CombinationLoadCaseCreate",
   "PATCH /job/loads/combination-load-cases/{id}": "CombinationLoadCaseUpdate",
+  "POST /job/structure/nodes/restraints/set-general": "SetGeneralRestraintRequest",
 };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/sdks/csharp/examples/Example.CreateSimpleBeam/Program.cs
+++ b/sdks/csharp/examples/Example.CreateSimpleBeam/Program.cs
@@ -127,9 +127,10 @@ try
 
     // == Step 8 — Apply the self-weight load =======================
     Console.WriteLine("Applying self-weight load...");
-    await client.Job.Loads.SelfWeightLoads[selfWeightCase.Id!.Value].PostAsync(
+    await client.Job.Loads.SelfWeightLoads.PostAsync(
         new SelfWeightLoadCreate
         {
+            Case = selfWeightCase.Id,
             AccelerationX = 0.0,
             AccelerationY = -1.0,    // 1 G downward
             AccelerationZ = 0.0,

--- a/sdks/python/examples/create_simple_beam/create_simple_beam.py
+++ b/sdks/python/examples/create_simple_beam/create_simple_beam.py
@@ -156,8 +156,9 @@ async def main() -> int:
 
         # == Step 8 — Apply the self-weight load =======================
         print("Applying self-weight load...")
-        await client.job.loads.self_weight_loads.by_case_id(self_weight_case.id).post(
+        await client.job.loads.self_weight_loads.post(
             SelfWeightLoadCreate(
+                case=self_weight_case.id,
                 acceleration_x=0.0,
                 acceleration_y=-1.0,    # 1 G downward
                 acceleration_z=0.0,


### PR DESCRIPTION
Build 14.50.71 removed POST /job/loads/self-weight-loads/{caseId} in favour of POST /job/loads/self-weight-loads with `case` set in the body. Update the C# + Python create_simple_beam examples and the simple-beam.mdx walkthrough to match. Add a snippet-generator override for the new POST /job/structure/nodes/restraints/set-general so the docs render `SetGeneralRestraintRequest` instead of the heuristic `SetGeneralCreate`.