### PR TITLE
sync: top-level restraints and flattened result endpoints (14.50.75)

### DIFF
--- a/docs/pages/guides/examples/simple-beam.mdx
+++ b/docs/pages/guides/examples/simple-beam.mdx
@@ -154,7 +154,8 @@ print(f"Node {node2.id}: ({node2.x}, {node2.y}, {node2.z})")
 
 ## Step 3 — Apply Restraints
 
-Restraints are attached to a node via `Nodes[id].Restraint`. The
+Restraints are top-level entities — POST a `NodeRestraintCreate` (with
+`Node` set on the body) to `Job.Structure.NodeRestraints`. The
 6-character `RestraintCode` maps to the TX, TY, TZ, RX, RY, RZ DOFs.
 Each character is one of:
 
@@ -174,22 +175,22 @@ rotations released).
 <CodeTabs>
 ```csharp title="C#"
 // Node 1: Fully fixed support (all 6 DOFs Fixed)
-await client.Job.Structure.Nodes[node1.Id.Value].Restraint.PostAsync(
-    new NodeRestraintCreate { RestraintCode = "FFFFFF" });
+await client.Job.Structure.NodeRestraints.PostAsync(
+    new NodeRestraintCreate { Node = node1.Id, RestraintCode = "FFFFFF" });
 
 // Node 2: Pinned support (translations Fixed, rotations Released)
-await client.Job.Structure.Nodes[node2.Id.Value].Restraint.PostAsync(
-    new NodeRestraintCreate { RestraintCode = "FFFRRR" });
+await client.Job.Structure.NodeRestraints.PostAsync(
+    new NodeRestraintCreate { Node = node2.Id, RestraintCode = "FFFRRR" });
 ```
 
 ```python title="Python"
 # Node 1: Fully fixed support (all 6 DOFs Fixed)
-await client.job.structure.nodes.by_id(node1.id).restraint.post(
-    NodeRestraintCreate(restraint_code="FFFFFF"))
+await client.job.structure.node_restraints.post(
+    NodeRestraintCreate(node=node1.id, restraint_code="FFFFFF"))
 
 # Node 2: Pinned support (translations Fixed, rotations Released)
-await client.job.structure.nodes.by_id(node2.id).restraint.post(
-    NodeRestraintCreate(restraint_code="FFFRRR"))
+await client.job.structure.node_restraints.post(
+    NodeRestraintCreate(node=node2.id, restraint_code="FFFRRR"))
 ```
 </CodeTabs>
 
@@ -618,7 +619,7 @@ rows.
 
 <CodeTabs>
 ```csharp title="C#"
-var reactions = await client.Job.Query.Analysis.Static.Node.Reactions.GetAsync(
+var reactions = await client.Job.Query.Analysis.Static.NodeReactions.GetAsync(
     config => config.QueryParameters.Cases = $"{ulsCase.Id}");
 
 if (reactions.Warnings?.CasesNotAnalyzed is { Length: > 0 } missing)
@@ -636,11 +637,11 @@ foreach (var r in reactions.Results)
 
 ```python title="Python"
 from kiota_abstractions.base_request_configuration import RequestConfiguration
-from space_gass_api.job.query.analysis.static.node.reactions.reactions_request_builder import ReactionsRequestBuilder
+from space_gass_api.job.query.analysis.static.node_reactions.node_reactions_request_builder import NodeReactionsRequestBuilder
 
-reaction_params = ReactionsRequestBuilder.ReactionsRequestBuilderGetQueryParameters(
+reaction_params = NodeReactionsRequestBuilder.NodeReactionsRequestBuilderGetQueryParameters(
     cases=str(uls_case.id))
-reactions = await client.job.query.analysis.static.node.reactions.get(
+reactions = await client.job.query.analysis.static.node_reactions.get(
     request_configuration=RequestConfiguration(query_parameters=reaction_params))
 
 if reactions.warnings and reactions.warnings.cases_not_analyzed:
@@ -676,7 +677,7 @@ Filter by ULS case + the member Id and take the maximum of `|Mz|`.
 
 <CodeTabs>
 ```csharp title="C#"
-var ulsForces = await client.Job.Query.Analysis.Static.Member.IntermediateForces
+var ulsForces = await client.Job.Query.Analysis.Static.MemberIntermediateForces
     .GetAsync(config =>
     {
         config.QueryParameters.Cases   = $"{ulsCase.Id}";
@@ -690,12 +691,12 @@ Console.WriteLine($"Max ULS bending moment on Member {member.Id}: {maxMz:F2} kNm
 ```
 
 ```python title="Python"
-from space_gass_api.job.query.analysis.static.member.intermediate_forces.intermediate_forces_request_builder import IntermediateForcesRequestBuilder
+from space_gass_api.job.query.analysis.static.member_intermediate_forces.member_intermediate_forces_request_builder import MemberIntermediateForcesRequestBuilder
 
-force_params = IntermediateForcesRequestBuilder.IntermediateForcesRequestBuilderGetQueryParameters(
+force_params = MemberIntermediateForcesRequestBuilder.MemberIntermediateForcesRequestBuilderGetQueryParameters(
     cases=str(uls_case.id),
     members=str(member.id))
-uls_forces = await client.job.query.analysis.static.member.intermediate_forces.get(
+uls_forces = await client.job.query.analysis.static.member_intermediate_forces.get(
     request_configuration=RequestConfiguration(query_parameters=force_params))
 
 beam_forces = uls_forces.results[0]
@@ -728,7 +729,7 @@ case + the member Id and take the maximum of `|TyGlobal|`.
 
 <CodeTabs>
 ```csharp title="C#"
-var slsDisplacements = await client.Job.Query.Analysis.Static.Member.IntermediateDisplacements
+var slsDisplacements = await client.Job.Query.Analysis.Static.MemberIntermediateDisplacements
     .GetAsync(config =>
     {
         config.QueryParameters.Cases   = $"{slsCase.Id}";
@@ -742,12 +743,12 @@ Console.WriteLine($"Max SLS midspan deflection on Member {member.Id}: {maxDeflec
 ```
 
 ```python title="Python"
-from space_gass_api.job.query.analysis.static.member.intermediate_displacements.intermediate_displacements_request_builder import IntermediateDisplacementsRequestBuilder
+from space_gass_api.job.query.analysis.static.member_intermediate_displacements.member_intermediate_displacements_request_builder import MemberIntermediateDisplacementsRequestBuilder
 
-displ_params = IntermediateDisplacementsRequestBuilder.IntermediateDisplacementsRequestBuilderGetQueryParameters(
+displ_params = MemberIntermediateDisplacementsRequestBuilder.MemberIntermediateDisplacementsRequestBuilderGetQueryParameters(
     cases=str(sls_case.id),
     members=str(member.id))
-sls_displacements = await client.job.query.analysis.static.member.intermediate_displacements.get(
+sls_displacements = await client.job.query.analysis.static.member_intermediate_displacements.get(
     request_configuration=RequestConfiguration(query_parameters=displ_params))
 
 beam_displacements = sls_displacements.results[0]

--- a/docs/pages/guides/filtering-and-querying.mdx
+++ b/docs/pages/guides/filtering-and-querying.mdx
@@ -68,7 +68,7 @@ load case and entity key.
 
 <CodeTabs>
 ```csharp title="C#"
-var result = await client.Job.Query.Analysis.Static.Node.Reactions.GetAsync();
+var result = await client.Job.Query.Analysis.Static.NodeReactions.GetAsync();
 
 foreach (var r in result.Results)
 {
@@ -78,7 +78,7 @@ foreach (var r in result.Results)
 ```
 
 ```python title="Python"
-result = await client.job.query.analysis.static.node.reactions.get()
+result = await client.job.query.analysis.static.node_reactions.get()
 
 for r in result.results:
     print(f"Case {r.case}, Node {r.node}: "
@@ -86,7 +86,7 @@ for r in result.results:
 ```
 
 ```bash title="curl"
-curl http://localhost:34560/api/v1/job/query/analysis/static/node/reactions
+curl http://localhost:34560/api/v1/job/query/analysis/static/node-reactions
 ```
 </CodeTabs>
 
@@ -98,7 +98,7 @@ or omit the parameter to return all results.
 
 <CodeTabs>
 ```csharp title="C#"
-var result = await client.Job.Query.Analysis.Static.Node.Displacements
+var result = await client.Job.Query.Analysis.Static.NodeDisplacements
     .GetAsync(config =>
     {
         config.QueryParameters.Cases = "1,3";
@@ -107,7 +107,7 @@ var result = await client.Job.Query.Analysis.Static.Node.Displacements
 ```
 
 ```python title="Python"
-result = await client.job.query.analysis.static.node.displacements.get(
+result = await client.job.query.analysis.static.node_displacements.get(
     request_configuration=lambda c: (
         setattr(c.query_parameters, 'cases', '1,3'),
         setattr(c.query_parameters, 'nodes', '10-12')
@@ -115,7 +115,7 @@ result = await client.job.query.analysis.static.node.displacements.get(
 ```
 
 ```bash title="curl"
-curl "http://localhost:34560/api/v1/job/query/analysis/static/node/displacements?cases=1,3&nodes=10-12"
+curl "http://localhost:34560/api/v1/job/query/analysis/static/node-displacements?cases=1,3&nodes=10-12"
 ```
 </CodeTabs>
 
@@ -127,7 +127,7 @@ arrays indexed by station.
 
 <CodeTabs>
 ```csharp title="C#"
-var result = await client.Job.Query.Analysis.Static.Member.IntermediateForces
+var result = await client.Job.Query.Analysis.Static.MemberIntermediateForces
     .GetAsync(config =>
     {
         config.QueryParameters.Members = "1";
@@ -145,7 +145,7 @@ foreach (var m in result.Results)
 ```
 
 ```python title="Python"
-result = await client.job.query.analysis.static.member.intermediate_forces.get(
+result = await client.job.query.analysis.static.member_intermediate_forces.get(
     request_configuration=lambda c:
         setattr(c.query_parameters, 'members', '1'))
 
@@ -157,7 +157,7 @@ for m in result.results:
 ```
 
 ```bash title="curl"
-curl "http://localhost:34560/api/v1/job/query/analysis/static/member/intermediate-forces?members=1"
+curl "http://localhost:34560/api/v1/job/query/analysis/static/member-intermediate-forces?members=1"
 ```
 </CodeTabs>
 
@@ -248,7 +248,7 @@ default all results are returned. Use pagination for large result sets.
 <CodeTabs>
 ```csharp title="C#"
 // Get the first 100 node displacements
-var page1 = await client.Job.Query.Analysis.Static.Node.Displacements
+var page1 = await client.Job.Query.Analysis.Static.NodeDisplacements
     .GetAsync(config =>
     {
         config.QueryParameters.Offset = 0;
@@ -256,7 +256,7 @@ var page1 = await client.Job.Query.Analysis.Static.Node.Displacements
     });
 
 // Get the next 100
-var page2 = await client.Job.Query.Analysis.Static.Node.Displacements
+var page2 = await client.Job.Query.Analysis.Static.NodeDisplacements
     .GetAsync(config =>
     {
         config.QueryParameters.Offset = 100;
@@ -265,13 +265,13 @@ var page2 = await client.Job.Query.Analysis.Static.Node.Displacements
 ```
 
 ```python title="Python"
-page1 = await client.job.query.analysis.static.node.displacements.get(
+page1 = await client.job.query.analysis.static.node_displacements.get(
     request_configuration=lambda c: (
         setattr(c.query_parameters, 'offset', 0),
         setattr(c.query_parameters, 'limit', 100)
     ))
 
-page2 = await client.job.query.analysis.static.node.displacements.get(
+page2 = await client.job.query.analysis.static.node_displacements.get(
     request_configuration=lambda c: (
         setattr(c.query_parameters, 'offset', 100),
         setattr(c.query_parameters, 'limit', 100)
@@ -280,9 +280,9 @@ page2 = await client.job.query.analysis.static.node.displacements.get(
 
 ```bash title="curl"
 # Page 1
-curl "http://localhost:34560/api/v1/job/query/analysis/static/node/displacements?offset=0&limit=100"
+curl "http://localhost:34560/api/v1/job/query/analysis/static/node-displacements?offset=0&limit=100"
 
 # Page 2
-curl "http://localhost:34560/api/v1/job/query/analysis/static/node/displacements?offset=100&limit=100"
+curl "http://localhost:34560/api/v1/job/query/analysis/static/node-displacements?offset=100&limit=100"
 ```
 </CodeTabs>

--- a/docs/pages/guides/running-analysis.mdx
+++ b/docs/pages/guides/running-analysis.mdx
@@ -43,7 +43,7 @@ Console.WriteLine($"Analysis {result.Status} in {result.ElapsedTime}");
 if (result.Status == AnalysisRunStatus.Completed)
 {
     // Query results...
-    var reactions = await client.Job.Query.Analysis.Static.Node.Reactions.GetAsync();
+    var reactions = await client.Job.Query.Analysis.Static.NodeReactions.GetAsync();
     Console.WriteLine($"Got {reactions.Results.Count} reactions");
 }
 
@@ -103,7 +103,7 @@ print(f"Analysis {result.status} in {result.elapsed_time}")
 
 if result.status == AnalysisRunStatus.Completed:
     # Query results...
-    reactions = await client.job.query.analysis.static.node.reactions.get()
+    reactions = await client.job.query.analysis.static.node_reactions.get()
     print(f"Got {len(reactions.results)} reactions")
 
 await client.job.close.post()

--- a/docs/pages/guides/sdk-terminology.mdx
+++ b/docs/pages/guides/sdk-terminology.mdx
@@ -83,7 +83,7 @@ typed properties on a configuration object:
 
 <CodeTabs>
 ```csharp title="C#"
-await client.Job.Query.Analysis.Static.Node.Reactions.GetAsync(config =>
+await client.Job.Query.Analysis.Static.NodeReactions.GetAsync(config =>
 {
     config.QueryParameters.Cases = "1,3-7";
     config.QueryParameters.Nodes = "10-12";
@@ -92,16 +92,16 @@ await client.Job.Query.Analysis.Static.Node.Reactions.GetAsync(config =>
 
 ```python title="Python"
 from kiota_abstractions.base_request_configuration import RequestConfiguration
-from space_gass_api.job.query.analysis.static.node.reactions.reactions_request_builder import ReactionsRequestBuilder
+from space_gass_api.job.query.analysis.static.node_reactions.node_reactions_request_builder import NodeReactionsRequestBuilder
 
-params = ReactionsRequestBuilder.ReactionsRequestBuilderGetQueryParameters(
+params = NodeReactionsRequestBuilder.NodeReactionsRequestBuilderGetQueryParameters(
     cases="1,3-7", nodes="10-12")
-await client.job.query.analysis.static.node.reactions.get(
+await client.job.query.analysis.static.node_reactions.get(
     request_configuration=RequestConfiguration(query_parameters=params))
 ```
 
 ```bash title="curl"
-curl "http://localhost:34560/api/v1/job/query/analysis/static/node/reactions?cases=1,3-7&nodes=10-12"
+curl "http://localhost:34560/api/v1/job/query/analysis/static/node-reactions?cases=1,3-7&nodes=10-12"
 ```
 </CodeTabs>
 

--- a/docs/zudoku.config.tsx
+++ b/docs/zudoku.config.tsx
@@ -33,7 +33,7 @@ const BODY_TYPE_OVERRIDES: Record<string, string> = {
   "POST /job/structure/materials/library": "MaterialLibraryCreate",
   "POST /job/loads/combination-load-cases": "CombinationLoadCaseCreate",
   "PATCH /job/loads/combination-load-cases/{id}": "CombinationLoadCaseUpdate",
-  "POST /job/structure/nodes/restraints/set-general": "SetGeneralRestraintRequest",
+  "POST /job/structure/node-restraints/set-general": "SetGeneralRestraintRequest",
 };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/sdks/csharp/examples/Example.CreateSimpleBeam/Program.cs
+++ b/sdks/csharp/examples/Example.CreateSimpleBeam/Program.cs
@@ -69,12 +69,12 @@ try
     //   N = Friction (limit proportional to the normal-axis reaction)
     Console.WriteLine("Applying restraints...");
 
-    await client.Job.Structure.Nodes[node1.Id!.Value].Restraint.PostAsync(
-        new NodeRestraintCreate { RestraintCode = "FFFFFF" });
+    await client.Job.Structure.NodeRestraints.PostAsync(
+        new NodeRestraintCreate { Node = node1.Id, RestraintCode = "FFFFFF" });
     Console.WriteLine($"  Node {node1.Id}: Fixed (FFFFFF)");
 
-    await client.Job.Structure.Nodes[node2.Id!.Value].Restraint.PostAsync(
-        new NodeRestraintCreate { RestraintCode = "FFFRRR" });
+    await client.Job.Structure.NodeRestraints.PostAsync(
+        new NodeRestraintCreate { Node = node2.Id, RestraintCode = "FFFRRR" });
     Console.WriteLine($"  Node {node2.Id}: Pinned (FFFRRR)");
     Console.WriteLine();
 
@@ -259,7 +259,7 @@ try
 
     // == Step 15 — Query reactions =================================
     Console.WriteLine("Querying ULS reactions...");
-    var reactions = await client.Job.Query.Analysis.Static.Node.Reactions.GetAsync(
+    var reactions = await client.Job.Query.Analysis.Static.NodeReactions.GetAsync(
         config => config.QueryParameters.Cases = $"{ulsCase.Id}");
 
     if (reactions!.Warnings?.CasesNotAnalyzed is { Length: > 0 } missing)
@@ -276,7 +276,7 @@ try
     Console.WriteLine();
 
     // == Step 16 — Maximum ULS bending moment ======================
-    var ulsForces = await client.Job.Query.Analysis.Static.Member.IntermediateForces
+    var ulsForces = await client.Job.Query.Analysis.Static.MemberIntermediateForces
         .GetAsync(config =>
         {
             config.QueryParameters.Cases   = $"{ulsCase.Id}";
@@ -288,7 +288,7 @@ try
     Console.WriteLine($"Max ULS bending moment on Member {member.Id}: {maxMz:F2} kNm");
 
     // == Step 17 — Maximum SLS deflection ==========================
-    var slsDisplacements = await client.Job.Query.Analysis.Static.Member.IntermediateDisplacements
+    var slsDisplacements = await client.Job.Query.Analysis.Static.MemberIntermediateDisplacements
         .GetAsync(config =>
         {
             config.QueryParameters.Cases   = $"{slsCase.Id}";

--- a/sdks/csharp/examples/Example.QueryRestrainedNodes/Program.cs
+++ b/sdks/csharp/examples/Example.QueryRestrainedNodes/Program.cs
@@ -60,7 +60,7 @@ try
         // Nodes filter uses SG list format (e.g. "1,5-10") — comma-separated Ids works for an arbitrary set.
         var nodeFilter = string.Join(",", restrainedNodes.Where(n => n.Id != null).Select(n => n.Id!.Value));
 
-        var reactionResult = await client.Job.Query.Analysis.Static.Node.Reactions.GetAsync(config =>
+        var reactionResult = await client.Job.Query.Analysis.Static.NodeReactions.GetAsync(config =>
             config.QueryParameters.Nodes = nodeFilter);
 
         var reactions = reactionResult?.Results;

--- a/sdks/csharp/examples/Example.RunAnalysis/Program.cs
+++ b/sdks/csharp/examples/Example.RunAnalysis/Program.cs
@@ -163,7 +163,7 @@ try
     Console.WriteLine();
     Console.WriteLine("Querying node reactions...");
 
-    var queryResult = await client.Job.Query.Analysis.Static.Node.Reactions.GetAsync();
+    var queryResult = await client.Job.Query.Analysis.Static.NodeReactions.GetAsync();
     var reactions = queryResult?.Results;
     if (reactions != null && reactions.Count > 0)
     {

--- a/sdks/python/examples/create_simple_beam/create_simple_beam.py
+++ b/sdks/python/examples/create_simple_beam/create_simple_beam.py
@@ -50,9 +50,9 @@ from space_gass_api.models.self_weight_load_create import SelfWeightLoadCreate
 from space_gass_api.models.solver_type import SolverType
 from space_gass_api.models.static_settings_update import StaticSettingsUpdate
 
-from space_gass_api.job.query.analysis.static.member.intermediate_forces.intermediate_forces_request_builder import IntermediateForcesRequestBuilder
-from space_gass_api.job.query.analysis.static.member.intermediate_displacements.intermediate_displacements_request_builder import IntermediateDisplacementsRequestBuilder
-from space_gass_api.job.query.analysis.static.node.reactions.reactions_request_builder import ReactionsRequestBuilder
+from space_gass_api.job.query.analysis.static.member_intermediate_forces.member_intermediate_forces_request_builder import MemberIntermediateForcesRequestBuilder
+from space_gass_api.job.query.analysis.static.member_intermediate_displacements.member_intermediate_displacements_request_builder import MemberIntermediateDisplacementsRequestBuilder
+from space_gass_api.job.query.analysis.static.node_reactions.node_reactions_request_builder import NodeReactionsRequestBuilder
 
 # -- Configuration ------------------------------------------------
 save_file_path = os.path.join(
@@ -96,13 +96,13 @@ async def main() -> int:
         #   N = Friction (limit proportional to the normal-axis reaction)
         print("Applying restraints...")
 
-        await client.job.structure.nodes.by_id(node1.id).restraint.post(
-            NodeRestraintCreate(restraint_code="FFFFFF"),
+        await client.job.structure.node_restraints.post(
+            NodeRestraintCreate(node=node1.id, restraint_code="FFFFFF"),
         )
         print(f"  Node {node1.id}: Fixed (FFFFFF)")
 
-        await client.job.structure.nodes.by_id(node2.id).restraint.post(
-            NodeRestraintCreate(restraint_code="FFFRRR"),
+        await client.job.structure.node_restraints.post(
+            NodeRestraintCreate(node=node2.id, restraint_code="FFFRRR"),
         )
         print(f"  Node {node2.id}: Pinned (FFFRRR)")
         print()
@@ -282,9 +282,9 @@ async def main() -> int:
 
         # == Step 15 — Query reactions =================================
         print("Querying ULS reactions...")
-        reaction_params = ReactionsRequestBuilder.ReactionsRequestBuilderGetQueryParameters(
+        reaction_params = NodeReactionsRequestBuilder.NodeReactionsRequestBuilderGetQueryParameters(
             cases=str(uls_case.id))
-        reactions = await client.job.query.analysis.static.node.reactions.get(
+        reactions = await client.job.query.analysis.static.node_reactions.get(
             request_configuration=RequestConfiguration(query_parameters=reaction_params))
 
         if reactions.warnings and reactions.warnings.cases_not_analyzed:
@@ -299,10 +299,10 @@ async def main() -> int:
         print()
 
         # == Step 16 — Maximum ULS bending moment ======================
-        force_params = IntermediateForcesRequestBuilder.IntermediateForcesRequestBuilderGetQueryParameters(
+        force_params = MemberIntermediateForcesRequestBuilder.MemberIntermediateForcesRequestBuilderGetQueryParameters(
             cases=str(uls_case.id),
             members=str(member.id))
-        uls_forces = await client.job.query.analysis.static.member.intermediate_forces.get(
+        uls_forces = await client.job.query.analysis.static.member_intermediate_forces.get(
             request_configuration=RequestConfiguration(query_parameters=force_params))
 
         beam_forces = uls_forces.results[0]
@@ -310,10 +310,10 @@ async def main() -> int:
         print(f"Max ULS bending moment on Member {member.id}: {max_mz:.2f} kNm")
 
         # == Step 17 — Maximum SLS deflection ==========================
-        displ_params = IntermediateDisplacementsRequestBuilder.IntermediateDisplacementsRequestBuilderGetQueryParameters(
+        displ_params = MemberIntermediateDisplacementsRequestBuilder.MemberIntermediateDisplacementsRequestBuilderGetQueryParameters(
             cases=str(sls_case.id),
             members=str(member.id))
-        sls_displacements = await client.job.query.analysis.static.member.intermediate_displacements.get(
+        sls_displacements = await client.job.query.analysis.static.member_intermediate_displacements.get(
             request_configuration=RequestConfiguration(query_parameters=displ_params))
 
         beam_displacements = sls_displacements.results[0]

--- a/sdks/python/examples/query_restrained_nodes/query_restrained_nodes.py
+++ b/sdks/python/examples/query_restrained_nodes/query_restrained_nodes.py
@@ -22,7 +22,7 @@ from extensions.client_extensions import create_client
 from space_gass_api.models.open_job_request import OpenJobRequest
 from space_gass_api.models.node_type_filter import NodeTypeFilter
 from space_gass_api.job.structure.nodes.nodes_request_builder import NodesRequestBuilder
-from space_gass_api.job.query.analysis.static.node.reactions.reactions_request_builder import ReactionsRequestBuilder
+from space_gass_api.job.query.analysis.static.node_reactions.node_reactions_request_builder import NodeReactionsRequestBuilder
 
 # -- Configuration ------------------------------------------------
 # Update this path to match your local environment.
@@ -66,11 +66,11 @@ async def main() -> int:
             # Nodes filter uses SG list format (e.g. "1,5-10") — comma-separated Ids works for an arbitrary set.
             node_filter = ",".join(str(n.id) for n in restrained_nodes if n.id is not None)
 
-            reaction_params = ReactionsRequestBuilder.ReactionsRequestBuilderGetQueryParameters(
+            reaction_params = NodeReactionsRequestBuilder.NodeReactionsRequestBuilderGetQueryParameters(
                 nodes=node_filter,
             )
             reaction_config = RequestConfiguration(query_parameters=reaction_params)
-            reaction_result = await client.job.query.analysis.static.node.reactions.get(
+            reaction_result = await client.job.query.analysis.static.node_reactions.get(
                 request_configuration=reaction_config,
             )
 

--- a/sdks/python/examples/run_analysis/run_analysis.py
+++ b/sdks/python/examples/run_analysis/run_analysis.py
@@ -150,7 +150,7 @@ async def main() -> int:
         print()
         print("Querying node reactions...")
 
-        query_result = await client.job.query.analysis.static.node.reactions.get()
+        query_result = await client.job.query.analysis.static.node_reactions.get()
         reactions = query_result.results if query_result else None
         if reactions:
             print(f"  Found {len(reactions)} reaction result(s).")


### PR DESCRIPTION
Build 14.50.75 promotes node-restraints / node-constraints / member-offsets to top-level entity collections and flattens the analysis-result endpoints under /query/analysis/static/ to kebab-case (e.g. /static/node/reactions -> /static/node-reactions). Migrate the create_simple_beam, query_restrained_nodes, and run_analysis examples plus simple-beam.mdx, filtering-and-querying.mdx, running-analysis.mdx, and sdk-terminology.mdx to the new chains, builder class names, and curl URLs. Update the snippet-generator BODY_TYPE_OVERRIDES key for the renamed set-general path.