### PR TITLE
prep: publish workflow, package metadata, and branch rename to main

### DIFF
--- a/.claude/skills/sync-sdk-after-regen/SKILL.md
+++ b/.claude/skills/sync-sdk-after-regen/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sync-sdk-after-regen
-description: Use this skill in the space-gass-api repo whenever the OpenAPI spec or the regenerated Kiota SDK clients change — typically right after the `generate-clients` workflow lands a "regenerate SDK clients" commit on `develop`, or any time `descriptions/preview/openapi.json` is updated. It brings the hand-written C# and Python examples, the Zudoku docs pages, and the dynamic code-snippet generator back in line with the new SDK surface. Trigger phrases: "regenerated SDKs", "spec updated", "fix examples after regen", "sync after kiota", "update for new build", or after a commit titled "regenerate SDK clients".
+description: Use this skill in the space-gass-api repo whenever the OpenAPI spec or the regenerated Kiota SDK clients change — typically right after the `generate-clients` workflow lands a "regenerate SDK clients" commit on `main`, or any time `descriptions/preview/openapi.json` is updated. It brings the hand-written C# and Python examples, the Zudoku docs pages, and the dynamic code-snippet generator back in line with the new SDK surface. Trigger phrases: "regenerated SDKs", "spec updated", "fix examples after regen", "sync after kiota", "update for new build", or after a commit titled "regenerate SDK clients".
 ---
 
 # sync-sdk-after-regen

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -2,7 +2,7 @@ name: Deploy Documentation
 
 on:
   push:
-    branches: [develop]
+    branches: [main]
 
 permissions:
   contents: read

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -4,9 +4,62 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+
 jobs:
-  publish-nuget:
+  prepare:
     runs-on: ubuntu-latest
+    outputs:
+      nuget-version: ${{ steps.version.outputs.nuget }}
+      pypi-version: ${{ steps.version.outputs.pypi }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Resolve versions from spec and release tag
+        id: version
+        run: |
+          BASE=$(jq -r '.info["x-space-gass-build"]' descriptions/preview/openapi.json)
+          if [ -z "$BASE" ] || [ "$BASE" = "null" ]; then
+            echo "::error::info.x-space-gass-build is missing from descriptions/preview/openapi.json"
+            exit 1
+          fi
+
+          TAG="${{ github.event.release.tag_name }}"
+          TAG_VERSION="${TAG#v}"
+
+          if [[ "$TAG_VERSION" != "$BASE"* ]]; then
+            echo "::error::Release tag '$TAG' does not start with spec version '$BASE'"
+            exit 1
+          fi
+
+          SUFFIX="${TAG_VERSION#$BASE}"
+
+          NUGET="${BASE}${SUFFIX}"
+
+          if [ -z "$SUFFIX" ]; then
+            PYPI="$BASE"
+          else
+            PYPI=$(echo "${BASE}${SUFFIX}" | sed -E \
+              's/-alpha\.([0-9]+)/a\1/; s/-beta\.([0-9]+)/b\1/; s/-rc\.([0-9]+)/rc\1/')
+          fi
+
+          echo "nuget=$NUGET" >> "$GITHUB_OUTPUT"
+          echo "pypi=$PYPI" >> "$GITHUB_OUTPUT"
+
+          echo "### Versions" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Target | Version |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|--------|---------|" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Spec base | \`$BASE\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Release tag | \`$TAG\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| NuGet | \`$NUGET\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| PyPI | \`$PYPI\` |" >> "$GITHUB_STEP_SUMMARY"
+
+  publish-nuget:
+    needs: prepare
+    runs-on: ubuntu-latest
+    environment: publish
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -16,34 +69,26 @@ jobs:
         with:
           dotnet-version: "8.0.x"
 
-      - name: Extract version from spec
-        id: version
-        run: |
-          VERSION=$(jq -r '.info["x-space-gass-build"]' descriptions/preview/openapi.json)
-          if [ -z "$VERSION" ] || [ "$VERSION" = "null" ]; then
-            echo "::error::info.x-space-gass-build is missing from descriptions/preview/openapi.json"
-            exit 1
-          fi
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-
       - name: Restore dependencies
         working-directory: sdks/csharp/client
         run: dotnet restore
 
       - name: Build
         working-directory: sdks/csharp/client
-        run: dotnet build --configuration Release --no-restore -p:Version=${{ steps.version.outputs.version }}
+        run: dotnet build --configuration Release --no-restore -p:Version=${{ needs.prepare.outputs.nuget-version }}
 
       - name: Pack
         working-directory: sdks/csharp/client
-        run: dotnet pack --configuration Release --no-build -p:PackageVersion=${{ steps.version.outputs.version }} -o ./nupkg
+        run: dotnet pack --configuration Release --no-build -p:PackageVersion=${{ needs.prepare.outputs.nuget-version }} -o ./nupkg
 
       - name: Push to NuGet
         working-directory: sdks/csharp/client
-        run: dotnet nuget push ./nupkg/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
+        run: dotnet nuget push ./nupkg/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
 
   publish-pypi:
+    needs: prepare
     runs-on: ubuntu-latest
+    environment: publish
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -53,23 +98,13 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Extract version from spec
-        id: version
-        run: |
-          VERSION=$(jq -r '.info["x-space-gass-build"]' descriptions/preview/openapi.json)
-          if [ -z "$VERSION" ] || [ "$VERSION" = "null" ]; then
-            echo "::error::info.x-space-gass-build is missing from descriptions/preview/openapi.json"
-            exit 1
-          fi
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-
       - name: Install build tools
         run: pip install build twine
 
       - name: Update version in pyproject.toml
         working-directory: sdks/python/client
         run: |
-          sed -i "s/^version = .*/version = \"${{ steps.version.outputs.version }}\"/" pyproject.toml
+          sed -i "s/^version = .*/version = \"${{ needs.prepare.outputs.pypi-version }}\"/" pyproject.toml
 
       - name: Build wheel
         working-directory: sdks/python/client

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,8 +10,8 @@ This is the public developer-facing repo for the SPACE GASS API. It contains the
 
 ### Branching
 
-- **Default branch:** `develop` (not `main`)
-- All CI workflows trigger on `develop`
+- **Default branch:** `main`
+- All CI workflows trigger on `main`
 
 ### Licensing
 
@@ -122,7 +122,7 @@ sdks/python/client/
 
 | Workflow | Trigger | Purpose |
 |---|---|---|
-| `deploy-docs.yml` | Push to `develop` | Build Zudoku site and deploy to GitHub Pages |
+| `deploy-docs.yml` | Push to `main` | Build Zudoku site and deploy to GitHub Pages |
 | `generate-clients.yml` | Manual (`workflow_dispatch`) | Run Kiota to regenerate SDK clients |
 | `publish-packages.yml` | GitHub Release published | Publish to NuGet and PyPI |
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,17 +17,17 @@ Thank you for your interest in contributing to the SPACE GASS API ecosystem! We 
 ### Examples and Sandbox Scripts
 
 1. Fork this repository
-2. Create a feature branch from `develop`
+2. Create a feature branch from `main`
 3. Add your example in the appropriate `sdks/*/examples/` directory, or create a new folder under `sandbox/`
 4. Ensure your example includes a README explaining what it demonstrates
-5. Open a Pull Request against `develop`
+5. Open a Pull Request against `main`
 
 ### Documentation
 
 1. Fork this repository
 2. Edit or add MDX pages under `docs/pages/`
 3. Test locally with `cd docs && npm run dev`
-4. Open a Pull Request against `develop`
+4. Open a Pull Request against `main`
 
 ### Bug Reports and Feature Requests
 

--- a/docs/zudoku.config.tsx
+++ b/docs/zudoku.config.tsx
@@ -394,7 +394,7 @@ const config: ZudokuConfig = {
     publishMarkdown: true,
     defaultOptions: {
       suggestEdit: {
-        url: "https://github.com/Spacegass/space-gass-api/edit/develop/docs/pages",
+        url: "https://github.com/Spacegass/space-gass-api/edit/main/docs/pages",
       },
     },
   },

--- a/sdks/csharp/client/SpaceGassApi/README.md
+++ b/sdks/csharp/client/SpaceGassApi/README.md
@@ -25,4 +25,4 @@ await client.Job.Close.PostAsync();
 
 - [Getting Started](https://api.spacegass.com/docs/)
 - [API Reference](https://api.spacegass.com/docs/api)
-- [Examples](https://github.com/Spacegass/space-gass-api/tree/develop/sdks/csharp/examples)
+- [Examples](https://github.com/Spacegass/space-gass-api/tree/main/sdks/csharp/examples)

--- a/sdks/csharp/client/SpaceGassApi/SpaceGassApi.csproj
+++ b/sdks/csharp/client/SpaceGassApi/SpaceGassApi.csproj
@@ -19,6 +19,7 @@
     <RepositoryType>git</RepositoryType>
     <PackageTags>spacegass;structural-analysis;api;sdk;kiota</PackageTags>
     <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageIcon>icon.png</PackageIcon>
   </PropertyGroup>
 
   <ItemGroup>
@@ -33,6 +34,7 @@
 
   <ItemGroup>
     <None Include="README.md" Pack="true" PackagePath="\" />
+    <None Include="icon.png" Pack="true" PackagePath="\" />
   </ItemGroup>
 
 </Project>

--- a/sdks/python/client/README.md
+++ b/sdks/python/client/README.md
@@ -118,4 +118,4 @@ registration needed.
 
 - [Getting Started](https://api.spacegass.com/docs/)
 - [API Reference](https://api.spacegass.com/docs/api)
-- [Examples](https://github.com/Spacegass/space-gass-api/tree/develop/sdks/python/examples)
+- [Examples](https://github.com/Spacegass/space-gass-api/tree/main/sdks/python/examples)

--- a/sdks/python/client/pyproject.toml
+++ b/sdks/python/client/pyproject.toml
@@ -31,3 +31,6 @@ Issues = "https://github.com/Spacegass/space-gass-api/issues"
 [tool.setuptools.packages.find]
 include = ["space_gass_api*"]
 namespaces = true
+
+[tool.setuptools.package-data]
+space_gass_api = ["py.typed", "*.pyi"]


### PR DESCRIPTION
- Refactor publish-packages.yml: shared prepare job extracts versions from spec + release tag, formats pre-release suffixes per-ecosystem (NuGet SemVer / PyPI PEP 440), adds --skip-duplicate, environment gate, and permissions: contents: read
- Add py.typed marker and package-data config for PEP 561 type support
- Add PackageIcon reference to .csproj (icon.png to be added separately)
- Rename all branch references from develop to main across workflows, docs, READMEs, CONTRIBUTING.md, and skill files