### PR TITLE
Add plate example

### DIFF
--- a/sdks/csharp/client/SpaceGassApi/SpaceGassApi.csproj
+++ b/sdks/csharp/client/SpaceGassApi/SpaceGassApi.csproj
@@ -29,6 +29,7 @@
   <ItemGroup>
     <Compile Include="Generated\**\*.cs" />
     <Compile Include="SpaceGassApiClient.cs" />
+    <Compile Include="Utils\**\*.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/sdks/csharp/client/SpaceGassApi/SpaceGassApi.csproj
+++ b/sdks/csharp/client/SpaceGassApi/SpaceGassApi.csproj
@@ -1,11 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <RootNamespace>SpaceGassApi</RootNamespace>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
-    <ImplicitUsings>enable</ImplicitUsings>
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
 
     <!-- NuGet package metadata -->

--- a/sdks/csharp/client/SpaceGassApi/SpaceGassApiClient.cs
+++ b/sdks/csharp/client/SpaceGassApi/SpaceGassApiClient.cs
@@ -1,79 +1,84 @@
+using System;
 using System.Net.Http;
 using Microsoft.Kiota.Abstractions;
 using Microsoft.Kiota.Abstractions.Authentication;
 using Microsoft.Kiota.Http.HttpClientLibrary;
 using Microsoft.Kiota.Http.HttpClientLibrary.Middleware.Options;
 
-namespace SpaceGassApi;
-
-/// <summary>
-/// SPACE GASS API client.
-/// Extends the Kiota-generated <see cref="BaseSpaceGassApiClient"/> with a
-/// convenience factory. Use <see cref="CreateClient"/> to get a fully
-/// configured instance.
-/// </summary>
-/// <remarks>
-/// This file lives outside the <c>Generated/</c> folder and is safe
-/// from <c>--clean-output</c> during Kiota regeneration.
-/// </remarks>
-public class SpaceGassApiClient : BaseSpaceGassApiClient
+namespace SpaceGassApi
 {
-    private const string ApiPath = "/api/v1";
-
     /// <summary>
-    /// Default base URL for the SPACE GASS API running locally.
+    /// SPACE GASS API client.
+    /// Extends the Kiota-generated <see cref="BaseSpaceGassApiClient"/> with a
+    /// convenience factory. Use <see cref="CreateClient"/> to get a fully
+    /// configured instance.
     /// </summary>
-    public const string DefaultBaseUrl = "http://localhost:34560";
-
-    /// <summary>
-    /// Initialises a new <see cref="SpaceGassApiClient"/>.
-    /// </summary>
-    /// <param name="requestAdapter">The request adapter to use.</param>
-    public SpaceGassApiClient(IRequestAdapter requestAdapter)
-        : base(requestAdapter)
-    {
-    }
-
-    /// <summary>
-    /// Create a <see cref="SpaceGassApiClient"/> with default settings.
-    /// </summary>
-    /// <param name="baseUrl">
-    /// Root URL of the SPACE GASS API (without <c>/api/v1</c>).
-    /// Defaults to <c>http://localhost:34560</c>.
-    /// Use <c>https://</c> for HTTPS connections.
-    /// </param>
-    /// <returns>A configured client ready to make API calls.</returns>
     /// <remarks>
-    /// The local SPACE GASS API may serve HTTPS with a self-signed
-    /// certificate, so SSL verification is disabled by default.
-    /// HTTP-to-HTTPS redirects are also allowed so either scheme
-    /// works for the same port.
+    /// This file lives outside the <c>Generated/</c> folder and is safe
+    /// from <c>--clean-output</c> during Kiota regeneration.
     /// </remarks>
-    public static SpaceGassApiClient CreateClient(string baseUrl = DefaultBaseUrl)
+    public class SpaceGassApiClient : BaseSpaceGassApiClient
     {
-        // Accept self-signed certificates from the local API.
-        var handler = new HttpClientHandler
+        private const string ApiPath = "/api/v1";
+
+        /// <summary>
+        /// Default base URL for the SPACE GASS API running locally.
+        /// </summary>
+        public const string DefaultBaseUrl = "http://localhost:34560";
+
+        /// <summary>
+        /// Initialises a new <see cref="SpaceGassApiClient"/>.
+        /// </summary>
+        /// <param name="requestAdapter">The request adapter to use.</param>
+        public SpaceGassApiClient(IRequestAdapter requestAdapter)
+            : base(requestAdapter)
         {
-            ServerCertificateCustomValidationCallback =
-                HttpClientHandler.DangerousAcceptAnyServerCertificateValidator,
-        };
+        }
 
-        // Allow HTTP ↔ HTTPS redirects (the local API may redirect).
-        var httpClient = KiotaClientFactory.Create(
-            handler,
-            [
-                new RedirectHandlerOption
+        /// <summary>
+        /// Create a <see cref="SpaceGassApiClient"/> with default settings.
+        /// </summary>
+        /// <param name="baseUrl">
+        /// Root URL of the SPACE GASS API (without <c>/api/v1</c>).
+        /// Defaults to <c>http://localhost:34560</c>.
+        /// Use <c>https://</c> for HTTPS connections.
+        /// </param>
+        /// <returns>A configured client ready to make API calls.</returns>
+        /// <remarks>
+        /// The local SPACE GASS API may serve HTTPS with a self-signed
+        /// certificate, so SSL verification is disabled by default.
+        /// HTTP-to-HTTPS redirects are also allowed so either scheme
+        /// works for the same port.
+        /// </remarks>
+        public static SpaceGassApiClient CreateClient(string baseUrl = DefaultBaseUrl)
+        {
+            var handler = new HttpClientHandler
+            {
+#if NETSTANDARD2_1_OR_GREATER
+                ServerCertificateCustomValidationCallback =
+                    HttpClientHandler.DangerousAcceptAnyServerCertificateValidator,
+#else
+                ServerCertificateCustomValidationCallback = (message, cert, chain, errors) => true,
+#endif
+            };
+
+            var httpClient = KiotaClientFactory.Create(
+                handler,
+                new IRequestOption[]
                 {
-                    AllowRedirectOnSchemeChange = true,
-                },
-            ]);
+                    new RedirectHandlerOption
+                    {
+                        AllowRedirectOnSchemeChange = true,
+                    },
+                });
 
-        httpClient.Timeout = TimeSpan.FromMinutes(30);
+            httpClient.Timeout = TimeSpan.FromMinutes(30);
 
-        var adapter = new HttpClientRequestAdapter(
-            new AnonymousAuthenticationProvider(),
-            httpClient: httpClient);
-        adapter.BaseUrl = baseUrl.TrimEnd('/') + ApiPath;
-        return new SpaceGassApiClient(adapter);
+            var adapter = new HttpClientRequestAdapter(
+                new AnonymousAuthenticationProvider(),
+                httpClient: httpClient);
+            adapter.BaseUrl = baseUrl.TrimEnd('/') + ApiPath;
+            return new SpaceGassApiClient(adapter);
+        }
     }
 }

--- a/sdks/csharp/client/SpaceGassApi/Utils/ListUtilsExtensions.cs
+++ b/sdks/csharp/client/SpaceGassApi/Utils/ListUtilsExtensions.cs
@@ -1,0 +1,132 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace SpaceGassApi.Utils
+{
+    /// <summary>
+    /// Extension methods for converting between integer ID collections and
+    /// the compact SPACE GASS filter string format (e.g. "1,3-7,10").
+    /// </summary>
+    public static class ListUtilsExtensions
+    {
+        /// <summary>
+        /// Converts a collection of integer IDs to a compact filter string.
+        /// Non-positive values are ignored. The output is sorted and deduplicated.
+        /// Runs of 3+ consecutive values collapse to ranges (e.g. "3-7").
+        /// </summary>
+        public static string ToFilterString(this IEnumerable<int> ids)
+        {
+            if (ids == null)
+                return string.Empty;
+
+            var sorted = ids.Where(id => id > 0).Distinct().OrderBy(id => id).ToList();
+            if (sorted.Count == 0)
+                return string.Empty;
+
+            var sb = new StringBuilder();
+            int runStart = sorted[0];
+            int runEnd = sorted[0];
+
+            for (int i = 1; i < sorted.Count; i++)
+            {
+                if (sorted[i] == runEnd + 1)
+                {
+                    runEnd = sorted[i];
+                }
+                else
+                {
+                    AppendRun(sb, runStart, runEnd);
+                    runStart = sorted[i];
+                    runEnd = sorted[i];
+                }
+            }
+
+            AppendRun(sb, runStart, runEnd);
+            return sb.ToString();
+        }
+
+        /// <summary>
+        /// Parses a SPACE GASS filter string into a sorted, distinct array of positive integers.
+        /// Ranges like "3-7" expand to all values in the inclusive range.
+        /// Reversed ranges like "7-3" are normalised.
+        /// Whitespace around tokens is tolerated.
+        /// </summary>
+        /// <exception cref="FormatException">
+        /// Thrown when the string contains non-numeric characters, non-positive values,
+        /// or the keyword "all".
+        /// </exception>
+        public static int[] ToIdArray(this string filter)
+        {
+            if (string.IsNullOrWhiteSpace(filter))
+                return Array.Empty<int>();
+
+            var result = new List<int>();
+            var tokens = filter.Split(',');
+
+            foreach (var raw in tokens)
+            {
+                var token = raw.Trim();
+                if (token.Length == 0)
+                    continue;
+
+                if (token.Equals("all", StringComparison.OrdinalIgnoreCase))
+                    throw new FormatException("The keyword \"all\" is not a valid ID list.");
+
+                var dashIndex = token.IndexOf('-');
+                if (dashIndex > 0)
+                {
+                    var startStr = token.Substring(0, dashIndex).Trim();
+                    var endStr = token.Substring(dashIndex + 1).Trim();
+
+                    if (!int.TryParse(startStr, out int start) || !int.TryParse(endStr, out int end))
+                        throw new FormatException($"Invalid token in ID list: \"{token}\".");
+
+                    int lo = Math.Min(start, end);
+                    int hi = Math.Max(start, end);
+                    for (int v = lo; v <= hi; v++)
+                        result.Add(v);
+                }
+                else
+                {
+                    if (!int.TryParse(token, out int value))
+                        throw new FormatException($"Invalid token in ID list: \"{token}\".");
+
+                    result.Add(value);
+                }
+            }
+
+            var sorted = result.Distinct().OrderBy(id => id).ToArray();
+
+            foreach (var id in sorted)
+            {
+                if (id <= 0)
+                    throw new FormatException($"Non-positive ID \"{id}\" is not valid.");
+            }
+
+            return sorted;
+        }
+
+        /// <summary>
+        /// Convenience wrapper that returns a <see cref="List{T}"/> instead of an array.
+        /// </summary>
+        public static List<int> ToIdList(this string filter)
+        {
+            return filter.ToIdArray().ToList();
+        }
+
+        private static void AppendRun(StringBuilder sb, int start, int end)
+        {
+            if (sb.Length > 0)
+                sb.Append(',');
+
+            if (end - start >= 2)
+                sb.Append(start).Append('-').Append(end);
+            else if (end - start == 1)
+                sb.Append(start).Append(',').Append(end);
+            else
+                sb.Append(start);
+        }
+    }
+}

--- a/sdks/csharp/examples/Example.CreateSimpleBeam/Program.cs
+++ b/sdks/csharp/examples/Example.CreateSimpleBeam/Program.cs
@@ -1,5 +1,6 @@
 using SpaceGassApi;
 using SpaceGassApi.Models;
+using SpaceGassApi.Utils;
 
 
 // ---------------------------------------------------------------
@@ -259,7 +260,7 @@ try
     // == Step 15 — Query reactions =================================
     Console.WriteLine("Querying ULS reactions...");
     var reactions = await client.Job.Query.Analysis.Static.NodeReactions.GetAsync(
-        config => config.QueryParameters.Cases = $"{ulsCase.Id}");
+        config => config.QueryParameters.Cases = new[] { ulsCase.Id!.Value }.ToFilterString());
 
     if (reactions!.Warnings?.CasesNotAnalyzed is { Length: > 0 } missing)
     {
@@ -278,8 +279,8 @@ try
     var ulsForces = await client.Job.Query.Analysis.Static.MemberIntermediateForces
         .GetAsync(config =>
         {
-            config.QueryParameters.Cases   = $"{ulsCase.Id}";
-            config.QueryParameters.Members = $"{member.Id}";
+            config.QueryParameters.Cases   = new[] { ulsCase.Id!.Value }.ToFilterString();
+            config.QueryParameters.Members = new[] { member.Id!.Value }.ToFilterString();
         });
 
     var beamForces = ulsForces!.Results!.First();
@@ -290,8 +291,8 @@ try
     var slsDisplacements = await client.Job.Query.Analysis.Static.MemberIntermediateDisplacements
         .GetAsync(config =>
         {
-            config.QueryParameters.Cases   = $"{slsCase.Id}";
-            config.QueryParameters.Members = $"{member.Id}";
+            config.QueryParameters.Cases   = new[] { slsCase.Id!.Value }.ToFilterString();
+            config.QueryParameters.Members = new[] { member.Id!.Value }.ToFilterString();
         });
 
     var beamDisplacements = slsDisplacements!.Results!.First();

--- a/sdks/csharp/examples/Example.CreateSimplePlate/Example.CreateSimplePlate.csproj
+++ b/sdks/csharp/examples/Example.CreateSimplePlate/Example.CreateSimplePlate.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+</Project>

--- a/sdks/csharp/examples/Example.CreateSimplePlate/Program.cs
+++ b/sdks/csharp/examples/Example.CreateSimplePlate/Program.cs
@@ -1,4 +1,3 @@
-using Microsoft.Kiota.Abstractions;
 using SpaceGassApi;
 using SpaceGassApi.Models;
 using SpaceGassApi.Utils;
@@ -447,15 +446,6 @@ catch (ErrorResponse err)
         Console.Error.WriteLine($"  Code: {err.ErrorCode}");
     foreach (var ve in err.Errors ?? [])
         Console.Error.WriteLine($"  [{ve.Field}] {ve.Message}");
-    Console.ResetColor();
-    return 1;
-}
-catch (ApiException apiEx)
-{
-    // HTTP-level API error that didn't deserialise as ErrorResponse
-    // (e.g. 500 Internal Server Error, unexpected content type)
-    Console.ForegroundColor = ConsoleColor.Red;
-    Console.Error.WriteLine($"API exception (HTTP {apiEx.ResponseStatusCode}): {apiEx.Message}");
     Console.ResetColor();
     return 1;
 }

--- a/sdks/csharp/examples/Example.CreateSimplePlate/Program.cs
+++ b/sdks/csharp/examples/Example.CreateSimplePlate/Program.cs
@@ -1,0 +1,485 @@
+using Microsoft.Kiota.Abstractions;
+using SpaceGassApi;
+using SpaceGassApi.Models;
+using SpaceGassApi.Utils;
+
+
+// ---------------------------------------------------------------
+// Example: Create a Simple Plate Model from Scratch
+//
+// Builds a 2 m wide x 10 m long simply-supported plate slab:
+//   1.  Create the client and a new project
+//   2.  Add a user-defined material (25 MPa concrete)
+//   3.  Bulk-create a rectangular grid of nodes (0.5 m spacing)
+//   4.  Apply restraints along the short edges
+//       - Pinned  (FFFRRR) at X = 0
+//       - Roller  (RFRRRR) at X = 10
+//   5.  Bulk-create quad plate elements across the grid
+//   6.  Check the errors log for engine-level diagnostics
+//   7.  Add plate cuts at the supports and midspan
+//   8.  Create load cases and combinations (same as SimpleBeam)
+//   9.  Apply self-weight and plate pressure loads
+//   10. Save the model
+//   11. Run a linear static analysis and wait for completion
+//   12. Query reactions
+//   13. Save the analysed model and close
+//
+// Prerequisites:
+//   - SPACE GASS API running locally (default: http://localhost:34560)
+// ---------------------------------------------------------------
+
+// -- Configuration ------------------------------------------------
+const double SpanLength = 10.0;   // metres (X direction)
+const double PlateWidth = 2.0;    // metres (Z direction)
+const double ElementSize = 0.5;   // metres (mesh spacing)
+const double Thickness = 0.2;     // metres (200 mm slab)
+
+var saveFilePath = Path.Combine(
+    Environment.GetFolderPath(Environment.SpecialFolder.Desktop),
+    "SpaceGass Examples",
+    "SimplePlate.sg");
+
+var client = SpaceGassApiClient.CreateClient("http://localhost:34560");
+
+try
+{
+    // == Step 1 — Create a new blank project =======================
+    Console.WriteLine("Creating new blank project...");
+    await client.Job.New.PostAsync();
+    Console.WriteLine("New project created.");
+    Console.WriteLine();
+
+    // == Step 2 — Add a user-defined material =====================
+    Console.WriteLine("Adding 25 MPa concrete material...");
+    var concrete = await client.Job.Structure.Materials.PostAsync(
+        new MaterialCreate
+        {
+            Name = "25 MPa Concrete",
+            YoungsModulus = 26700.0,       // MPa
+            PoissonsRatio = 0.2,
+            MassDensity = 2400.0,          // kg/m³
+            ThermalCoeff = 1.0e-5,         // per °C
+            ConcreteStrength = 25.0,       // MPa
+        });
+    Console.WriteLine($"  Material {concrete!.Id}: {concrete.Name}");
+    Console.WriteLine();
+
+    // == Step 3 — Bulk-create nodes ===============================
+    // Rectangular grid: X from 0..10 m, Z from 0..2 m
+    var nX = (int)(SpanLength / ElementSize) + 1;   // 21 nodes along X
+    var nZ = (int)(PlateWidth / ElementSize) + 1;    // 5 nodes across Z
+
+    Console.WriteLine($"Creating {nX} x {nZ} = {nX * nZ} node grid (bulk)...");
+
+    var nodeCreates = new List<NodeCreate>();
+    for (var ix = 0; ix < nX; ix++)
+    {
+        for (var iz = 0; iz < nZ; iz++)
+        {
+            nodeCreates.Add(new NodeCreate
+            {
+                X = ix * ElementSize,
+                Y = 0.0,
+                Z = iz * ElementSize,
+            });
+        }
+    }
+
+    var nodeResult = await client.Job.Structure.Nodes.Bulk.PostAsync(nodeCreates);
+    var createdNodes = nodeResult!.Succeeded!;
+    Console.WriteLine($"  {createdNodes.Count} nodes created");
+
+    if (nodeResult.Errors is { Count: > 0 } nodeErrors)
+    {
+        Console.ForegroundColor = ConsoleColor.Yellow;
+        Console.Error.WriteLine($"  WARNING: {nodeErrors.Count} node(s) failed:");
+        foreach (var e in nodeErrors)
+            Console.Error.WriteLine($"    [{e.Index}] {e.Error}");
+        Console.ResetColor();
+    }
+
+    // Build a lookup: [ix, iz] → node Id
+    var nodeId = new int[nX, nZ];
+    var idx = 0;
+    for (var ix = 0; ix < nX; ix++)
+    {
+        for (var iz = 0; iz < nZ; iz++)
+        {
+            nodeId[ix, iz] = createdNodes[idx++].Id!.Value;
+        }
+    }
+    Console.WriteLine();
+
+    // == Step 4 — Apply restraints along the short edges ==========
+    // Pinned at X = 0  (all translations fixed, rotations free)
+    // Roller at X = 10 (only TY fixed — free to slide in X and Z)
+    Console.WriteLine("Applying restraints...");
+
+    var restraintCreates = new List<NodeRestraintCreate>();
+
+    for (var iz = 0; iz < nZ; iz++)
+    {
+        // Pinned edge (X = 0)
+        restraintCreates.Add(new NodeRestraintCreate
+        {
+            Node = nodeId[0, iz],
+            RestraintCode = "FFFRRR",
+        });
+
+        // Roller edge (X = 10)
+        restraintCreates.Add(new NodeRestraintCreate
+        {
+            Node = nodeId[nX - 1, iz],
+            RestraintCode = "RFRRRR",
+        });
+    }
+
+    var restraintResult = await client.Job.Structure.NodeRestraints.Bulk.PostAsync(
+        restraintCreates);
+    Console.WriteLine($"  {restraintResult!.Succeeded!.Count} restraints applied");
+
+    if (restraintResult.Errors is { Count: > 0 } restraintErrors)
+    {
+        Console.ForegroundColor = ConsoleColor.Yellow;
+        Console.Error.WriteLine($"  WARNING: {restraintErrors.Count} restraint(s) failed:");
+        foreach (var e in restraintErrors)
+            Console.Error.WriteLine($"    [{e.Index}] {e.Error}");
+        Console.ResetColor();
+    }
+    Console.WriteLine();
+
+    // == Step 5 — Bulk-create quad plate elements ==================
+    // Each plate spans a 0.5 x 0.5 m cell in the grid.
+    // Node winding: A(ix,iz) → B(ix+1,iz) → C(ix+1,iz+1) → D(ix,iz+1)
+    var plateCountX = nX - 1;   // 20
+    var plateCountZ = nZ - 1;   // 4
+
+    Console.WriteLine($"Creating {plateCountX * plateCountZ} plate elements (bulk)...");
+
+    var plateCreates = new List<PlateCreate>();
+    for (var ix = 0; ix < plateCountX; ix++)
+    {
+        for (var iz = 0; iz < plateCountZ; iz++)
+        {
+            plateCreates.Add(new PlateCreate
+            {
+                NodeA = nodeId[ix, iz],
+                NodeB = nodeId[ix + 1, iz],
+                NodeC = nodeId[ix + 1, iz + 1],
+                NodeD = nodeId[ix, iz + 1],
+                Material = concrete.Id,
+                ActualThickness = Thickness * 1000,      // mm
+                MembraneThickness = Thickness * 1000,
+                BendingThickness = Thickness * 1000,
+                ShearThickness = Thickness * 1000,
+                Theory = PlateTheory.Mindlin,
+            });
+        }
+    }
+
+    var plateResult = await client.Job.Structure.Plates.Bulk.PostAsync(plateCreates);
+    var createdPlates = plateResult!.Succeeded!;
+    Console.WriteLine($"  {createdPlates.Count} plates created");
+
+    if (plateResult.Errors is { Count: > 0 } plateErrors)
+    {
+        Console.ForegroundColor = ConsoleColor.Yellow;
+        Console.Error.WriteLine($"  WARNING: {plateErrors.Count} plate(s) failed:");
+        foreach (var e in plateErrors)
+            Console.Error.WriteLine($"    [{e.Index}] {e.Error}");
+        Console.ResetColor();
+    }
+
+    if (createdPlates.Count == 0)
+    {
+        throw new Exception("No plates were created. Cannot continue.");
+    }
+    Console.WriteLine();
+
+    // == Step 6 — Check the errors log ============================
+    // The errors endpoint returns engine-level diagnostic messages
+    // logged during the session. Check it after creating plates to
+    // catch issues that the bulk result may not surface.
+    Console.WriteLine("Checking errors log...");
+    var errors = await client.Job.Errors.GetAsync();
+
+    if (errors!.Count > 0)
+    {
+        Console.ForegroundColor = ConsoleColor.Yellow;
+        Console.Error.WriteLine($"  {errors.Count} engine message(s):");
+        foreach (var msg in errors.Errors!)
+            Console.Error.WriteLine($"    {msg}");
+        Console.ResetColor();
+    }
+    else
+    {
+        Console.WriteLine("  No errors.");
+    }
+    Console.WriteLine();
+
+    // Build a lookup: [ix, iz] → plate Id
+    var plateId = new int[plateCountX, plateCountZ];
+    idx = 0;
+    for (var ix = 0; ix < plateCountX; ix++)
+    {
+        for (var iz = 0; iz < plateCountZ; iz++)
+        {
+            plateId[ix, iz] = createdPlates[idx++].Id!.Value;
+        }
+    }
+
+    // == Step 7 — Add plate cuts ==================================
+    // Three transverse cuts across the full plate width:
+    //   - Just inside the left support  (X = 0.5 m)
+    //   - At midspan                    (X = 5.0 m)
+    //   - Just inside the right support (X = 9.5 m)
+    //
+    // Each cut line runs from Z = 0 to Z = 2, which passes through
+    // plates in the same X-column. We specify start/end plates as
+    // the first and last plate in that column, and start/end nodes
+    // at Z = 0 and Z = 2 on the cut X-coordinate.
+    Console.WriteLine("Adding plate cuts...");
+
+    var cutDefinitions = new (string Title, int Ix, double CutX)[]
+    {
+        ("Left support (X=0.5m)",  1, 0.5),
+        ("Midspan (X=5.0m)",       10, 5.0),
+        ("Right support (X=9.5m)", 19, 9.5),
+    };
+
+    var cutCreates = new List<PlateCutCreate>();
+    foreach (var (title, cutIx, cutX) in cutDefinitions)
+    {
+        // The cut passes through the column of plates at index cutIx-1
+        // (plate column index is 0-based, cutIx is the node column).
+        // But the cut line is along the right edge of column cutIx-1,
+        // which means it starts at the first plate in that column and
+        // ends at the last plate in that column.
+        var startPlate = plateId[cutIx - 1, 0];             // bottom plate in the column
+        var endPlate = plateId[cutIx - 1, plateCountZ - 1]; // top plate in the column
+
+        // The start/end nodes define the line: Z=0 to Z=2 at X=cutX
+        var startNode = nodeId[cutIx, 0];
+        var endNode = nodeId[cutIx, nZ - 1];
+
+        cutCreates.Add(new PlateCutCreate
+        {
+            Title = title,
+            StartPlate = startPlate,
+            EndPlate = endPlate,
+            StartNode = startNode,
+            EndNode = endNode,
+        });
+    }
+
+    var cutResult = await client.Job.Structure.PlateCuts.Bulk.PostAsync(cutCreates);
+    Console.WriteLine($"  {cutResult!.Succeeded!.Count} plate cuts created");
+
+    if (cutResult.Errors is { Count: > 0 } cutErrors)
+    {
+        Console.ForegroundColor = ConsoleColor.Yellow;
+        Console.Error.WriteLine($"  WARNING: {cutErrors.Count} plate cut(s) failed:");
+        foreach (var e in cutErrors)
+            Console.Error.WriteLine($"    [{e.Index}] {e.Error}");
+        Console.ResetColor();
+    }
+    Console.WriteLine();
+
+    // == Step 8 — Create primary load cases ========================
+    Console.WriteLine("Creating primary load cases...");
+    var selfWeightCase = await client.Job.Loads.LoadCases.PostAsync(
+        new LoadCaseCreate { Id = 1, Title = "Self-weight" });
+    var deadCase = await client.Job.Loads.LoadCases.PostAsync(
+        new LoadCaseCreate { Id = 2, Title = "Dead Load" });
+    var liveCase = await client.Job.Loads.LoadCases.PostAsync(
+        new LoadCaseCreate { Id = 3, Title = "Live Load" });
+    Console.WriteLine($"  Cases: SW={selfWeightCase!.Id}, G={deadCase!.Id}, Q={liveCase!.Id}");
+    Console.WriteLine();
+
+    // == Step 9 — Apply the self-weight load =======================
+    Console.WriteLine("Applying self-weight load...");
+    await client.Job.Loads.SelfWeightLoads.PostAsync(
+        new SelfWeightLoadCreate
+        {
+            Case = selfWeightCase.Id,
+            AccelerationX = 0.0,
+            AccelerationY = -1.0,
+            AccelerationZ = 0.0,
+        });
+    Console.WriteLine();
+
+    // == Step 10 — Apply plate pressure loads ======================
+    // Dead load: 1.0 kPa superimposed dead load (on top of self-weight)
+    // Live load: 3.0 kPa (typical floor live load)
+    Console.WriteLine("Applying plate pressure loads...");
+
+    var pressureLoads = new List<PlatePressureLoadCreate>();
+    foreach (var plate in createdPlates)
+    {
+        // Dead load — 1.0 kPa downward
+        pressureLoads.Add(new PlatePressureLoadCreate
+        {
+            Case = deadCase.Id,
+            Plate = plate.Id,
+            Axes = LoadAxes.GlobalProjected,
+            Px = 0.0,
+            Py = -1.0,     // kPa
+            Pz = 0.0,
+        });
+
+        // Live load — 3.0 kPa downward
+        pressureLoads.Add(new PlatePressureLoadCreate
+        {
+            Case = liveCase.Id,
+            Plate = plate.Id,
+            Axes = LoadAxes.GlobalProjected,
+            Px = 0.0,
+            Py = -3.0,     // kPa
+            Pz = 0.0,
+        });
+    }
+
+    await client.Job.Loads.PlatePressureLoads.Bulk.PostAsync(pressureLoads);
+    Console.WriteLine($"  {pressureLoads.Count} pressure loads applied");
+    Console.WriteLine();
+
+    // == Step 11 — ULS and SLS combinations ========================
+    Console.WriteLine("Defining ULS and SLS combinations to AS/NZS 1170...");
+
+    var ulsCase = await client.Job.Loads.CombinationLoadCases.PostAsync(
+        new CombinationLoadCaseCreate
+        {
+            Id = 10,
+            Title = "ULS - Strength",
+            CombinationItems = new List<CombinationLoadCaseItem>
+            {
+                new() { Case = selfWeightCase.Id, MultiplyingFactor = 1.2 },
+                new() { Case = deadCase.Id,       MultiplyingFactor = 1.2 },
+                new() { Case = liveCase.Id,       MultiplyingFactor = 1.5 },
+            },
+        });
+
+    var slsCase = await client.Job.Loads.CombinationLoadCases.PostAsync(
+        new CombinationLoadCaseCreate
+        {
+            Id = 20,
+            Title = "SLS - Short-term Deflection",
+            CombinationItems = new List<CombinationLoadCaseItem>
+            {
+                new() { Case = selfWeightCase.Id, MultiplyingFactor = 1.0 },
+                new() { Case = deadCase.Id,       MultiplyingFactor = 1.0 },
+                new() { Case = liveCase.Id,       MultiplyingFactor = 0.7 },
+            },
+        });
+
+    Console.WriteLine($"  ULS  case Id = {ulsCase!.Id}");
+    Console.WriteLine($"  SLS  case Id = {slsCase!.Id}");
+    Console.WriteLine();
+
+    // == Step 12 — Save the initial model ==========================
+    Console.WriteLine($"Saving initial model to: {saveFilePath}");
+    await client.Job.Save.PostAsync(
+        new SaveJobRequest { FilePath = saveFilePath });
+    Console.WriteLine("Model saved.");
+    Console.WriteLine();
+
+    // == Step 13 — Run a linear static analysis ====================
+    Console.WriteLine("Configuring static analysis settings...");
+    await client.Job.Analysis.Static.Settings.PatchAsync(
+        new StaticSettingsUpdate
+        {
+            SolverType = SolverType.Paradise,
+        });
+
+    Console.WriteLine("Running linear static analysis...");
+    var run = await client.Job.Analysis.Static.RunLinear.PostAsync(
+        new StaticSettingsUpdate());
+    Console.WriteLine($"  Run {run!.RunId} queued; waiting for completion...");
+
+    AnalysisRun finalRun;
+    while (true)
+    {
+        await Task.Delay(500);
+        finalRun = (await client.Job.Analysis.Runs[run.RunId!.Value].GetAsync())!;
+        if (finalRun.Status is AnalysisRunStatus.Completed
+                            or AnalysisRunStatus.Failed
+                            or AnalysisRunStatus.Cancelled)
+        {
+            break;
+        }
+    }
+
+    Console.WriteLine($"  Analysis {finalRun.Status} in {finalRun.ElapsedTime}");
+    if (finalRun.Status != AnalysisRunStatus.Completed)
+    {
+        throw new Exception($"Analysis did not complete: {finalRun.ErrorMessage}");
+    }
+    Console.WriteLine();
+
+    // == Step 14 — Query reactions =================================
+    Console.WriteLine("Querying ULS reactions...");
+    var reactions = await client.Job.Query.Analysis.Static.NodeReactions.GetAsync(config =>
+    {
+        config.QueryParameters.Cases = new[] { ulsCase.Id!.Value }.ToFilterString();
+    });
+
+    Console.WriteLine($"  {"Node",-8} {"Fx",12} {"Fy",12} {"Fz",12} {"Mx",12} {"My",12} {"Mz",12}");
+    Console.WriteLine($"  {new string('-', 80)}");
+    foreach (var r in reactions!.Results!)
+    {
+        Console.WriteLine($"  {r.Node,-8} {r.Fx,12:F4} {r.Fy,12:F4} {r.Fz,12:F4} {r.Mx,12:F4} {r.My,12:F4} {r.Mz,12:F4}");
+    }
+    Console.WriteLine();
+
+    // == Step 15 — Save the analysed model =========================
+    Console.WriteLine($"Saving analysed model to: {saveFilePath}");
+    await client.Job.Save.PostAsync(new SaveJobRequest { FilePath = saveFilePath });
+    Console.WriteLine("Project saved.");
+}
+catch (ErrorResponse err)
+{
+    // Structured API error (validation failures, not-found, etc.)
+    Console.ForegroundColor = ConsoleColor.Red;
+    Console.Error.WriteLine($"API error {err.Status}: {err.Title}");
+    if (!string.IsNullOrWhiteSpace(err.Detail))
+        Console.Error.WriteLine($"  {err.Detail}");
+    if (!string.IsNullOrWhiteSpace(err.ErrorCode))
+        Console.Error.WriteLine($"  Code: {err.ErrorCode}");
+    foreach (var ve in err.Errors ?? [])
+        Console.Error.WriteLine($"  [{ve.Field}] {ve.Message}");
+    Console.ResetColor();
+    return 1;
+}
+catch (ApiException apiEx)
+{
+    // HTTP-level API error that didn't deserialise as ErrorResponse
+    // (e.g. 500 Internal Server Error, unexpected content type)
+    Console.ForegroundColor = ConsoleColor.Red;
+    Console.Error.WriteLine($"API exception (HTTP {apiEx.ResponseStatusCode}): {apiEx.Message}");
+    Console.ResetColor();
+    return 1;
+}
+catch (Exception ex)
+{
+    Console.ForegroundColor = ConsoleColor.Red;
+    Console.Error.WriteLine($"Error: {ex.Message}");
+    Console.ResetColor();
+    return 1;
+}
+finally
+{
+    try
+    {
+        Console.WriteLine("Closing project...");
+        await client.Job.Close.PostAsync();
+        Console.WriteLine("Project closed.");
+    }
+    catch (Exception closeEx)
+    {
+        Console.ForegroundColor = ConsoleColor.Yellow;
+        Console.Error.WriteLine($"Warning: failed to close job: {closeEx.Message}");
+        Console.ResetColor();
+    }
+}
+
+return 0;

--- a/sdks/csharp/examples/Example.CreateSinglePlate/Example.CreateSinglePlate.csproj
+++ b/sdks/csharp/examples/Example.CreateSinglePlate/Example.CreateSinglePlate.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+</Project>

--- a/sdks/csharp/examples/Example.CreateSinglePlate/Program.cs
+++ b/sdks/csharp/examples/Example.CreateSinglePlate/Program.cs
@@ -1,0 +1,157 @@
+using SpaceGassApi;
+using SpaceGassApi.Models;
+
+
+// ---------------------------------------------------------------
+// Example: Create a Single Plate
+//
+// Bare-minimum example that creates one quad plate element:
+//   1. New project
+//   2. Four nodes (1 m x 1 m square)
+//   3. One material
+//   4. One plate
+//   5. Check errors log
+//   6. Save and close
+// ---------------------------------------------------------------
+
+var saveFilePath = Path.Combine(
+    Environment.GetFolderPath(Environment.SpecialFolder.Desktop),
+    "SpaceGass Examples",
+    "SinglePlate.sg");
+
+var client = SpaceGassApiClient.CreateClient("http://localhost:34560");
+
+try
+{
+    // == New project ===============================================
+    Console.WriteLine("Creating new blank project...");
+    await client.Job.New.PostAsync();
+    Console.WriteLine("Done.");
+    Console.WriteLine();
+
+    // == Four corner nodes (1 m x 1 m in the XZ plane) ============
+    Console.WriteLine("Creating 4 nodes...");
+
+    var n1 = await client.Job.Structure.Nodes.PostAsync(
+        new NodeCreate { X = 0.0, Y = 0.0, Z = 0.0 });
+    Console.WriteLine($"  Node {n1!.Id}: ({n1.X}, {n1.Y}, {n1.Z})");
+
+    var n2 = await client.Job.Structure.Nodes.PostAsync(
+        new NodeCreate { X = 1.0, Y = 0.0, Z = 0.0 });
+    Console.WriteLine($"  Node {n2!.Id}: ({n2.X}, {n2.Y}, {n2.Z})");
+
+    var n3 = await client.Job.Structure.Nodes.PostAsync(
+        new NodeCreate { X = 1.0, Y = 0.0, Z = 1.0 });
+    Console.WriteLine($"  Node {n3!.Id}: ({n3.X}, {n3.Y}, {n3.Z})");
+
+    var n4 = await client.Job.Structure.Nodes.PostAsync(
+        new NodeCreate { X = 0.0, Y = 0.0, Z = 1.0 });
+    Console.WriteLine($"  Node {n4!.Id}: ({n4.X}, {n4.Y}, {n4.Z})");
+    Console.WriteLine();
+
+    // == Material =================================================
+    Console.WriteLine("Adding material...");
+    var mat = await client.Job.Structure.Materials.PostAsync(
+        new MaterialCreate
+        {
+            Name = "Concrete 25 MPa",
+            YoungsModulus = 26700.0,
+            PoissonsRatio = 0.2,
+            MassDensity = 2400.0,
+            ThermalCoeff = 1.0e-5,
+            ConcreteStrength = 25.0,
+        });
+    Console.WriteLine($"  Material {mat!.Id}: {mat.Name}");
+    Console.WriteLine();
+
+    // == Single plate =============================================
+    Console.WriteLine("Creating plate...");
+    var plate = await client.Job.Structure.Plates.PostAsync(
+        new PlateCreate
+        {
+            NodeA = n1.Id,
+            NodeB = n2.Id,
+            NodeC = n3.Id,
+            NodeD = n4.Id,
+            Material = mat.Id,
+            ActualThickness = 200.0,       // mm
+            MembraneThickness = 200.0,
+            BendingThickness = 200.0,
+            ShearThickness = 200.0,
+            Theory = PlateTheory.Mindlin,
+        });
+    Console.WriteLine($"  Plate {plate!.Id}: nodes [{plate.NodeA},{plate.NodeB},{plate.NodeC},{plate.NodeD}]");
+    Console.WriteLine();
+
+    // == Verify plate exists via GET ==============================
+    Console.WriteLine("Querying plates...");
+    var plates = await client.Job.Structure.Plates.GetAsync();
+    Console.WriteLine($"  {plates!.Count} plate(s) returned:");
+    foreach (var p in plates)
+    {
+        Console.WriteLine($"    Plate {p.Id}: nodes [{p.NodeA},{p.NodeB},{p.NodeC},{p.NodeD}], " +
+                          $"material={p.Material}, thickness={p.ActualThickness}, theory={p.Theory}");
+    }
+    Console.WriteLine();
+
+    // == Check errors log =========================================
+    Console.WriteLine("Checking errors log...");
+    var errors = await client.Job.Errors.GetAsync();
+
+    if (errors!.Count > 0)
+    {
+        Console.ForegroundColor = ConsoleColor.Yellow;
+        Console.Error.WriteLine($"  {errors.Count} engine message(s):");
+        foreach (var msg in errors.Errors!)
+            Console.Error.WriteLine($"    {msg}");
+        Console.ResetColor();
+    }
+    else
+    {
+        Console.WriteLine("  No errors.");
+    }
+    Console.WriteLine();
+
+    // == Save =====================================================
+    Console.WriteLine($"Saving to: {saveFilePath}");
+    await client.Job.Save.PostAsync(
+        new SaveJobRequest { FilePath = saveFilePath });
+    Console.WriteLine("Saved.");
+}
+catch (ErrorResponse err)
+{
+    Console.ForegroundColor = ConsoleColor.Red;
+    Console.Error.WriteLine($"API error {err.Status}: {err.Title}");
+    if (!string.IsNullOrWhiteSpace(err.Detail))
+        Console.Error.WriteLine($"  {err.Detail}");
+    if (!string.IsNullOrWhiteSpace(err.ErrorCode))
+        Console.Error.WriteLine($"  Code: {err.ErrorCode}");
+    foreach (var ve in err.Errors ?? [])
+        Console.Error.WriteLine($"  [{ve.Field}] {ve.Message}");
+    Console.ResetColor();
+    return 1;
+}
+catch (Exception ex)
+{
+    Console.ForegroundColor = ConsoleColor.Red;
+    Console.Error.WriteLine($"Error: {ex.Message}");
+    Console.ResetColor();
+    return 1;
+}
+finally
+{
+    try
+    {
+        Console.WriteLine("Closing project...");
+        await client.Job.Close.PostAsync();
+        Console.WriteLine("Closed.");
+    }
+    catch (Exception closeEx)
+    {
+        Console.ForegroundColor = ConsoleColor.Yellow;
+        Console.Error.WriteLine($"Warning: failed to close job: {closeEx.Message}");
+        Console.ResetColor();
+    }
+}
+
+return 0;

--- a/sdks/csharp/examples/Example.QueryRestrainedNodes/Program.cs
+++ b/sdks/csharp/examples/Example.QueryRestrainedNodes/Program.cs
@@ -1,5 +1,6 @@
 using SpaceGassApi;
 using SpaceGassApi.Models;
+using SpaceGassApi.Utils;
 
 
 // ---------------------------------------------------------------
@@ -56,8 +57,7 @@ try
         Console.WriteLine();
         Console.WriteLine("Retrieving reactions for restrained nodes...");
 
-        // Nodes filter uses SG list format (e.g. "1,5-10") — comma-separated Ids works for an arbitrary set.
-        var nodeFilter = string.Join(",", restrainedNodes.Where(n => n.Id != null).Select(n => n.Id!.Value));
+        var nodeFilter = restrainedNodes.Where(n => n.Id != null).Select(n => n.Id!.Value).ToFilterString();
 
         var reactionResult = await client.Job.Query.Analysis.Static.NodeReactions.GetAsync(config =>
             config.QueryParameters.Nodes = nodeFilter);

--- a/sdks/csharp/examples/SpaceGassApi.Examples.sln
+++ b/sdks/csharp/examples/SpaceGassApi.Examples.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 17
-VisualStudioVersion = 17.0.31903.59
+# Visual Studio Version 18
+VisualStudioVersion = 18.6.11709.129 insiders
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Example.QueryRestrainedNodes", "Example.QueryRestrainedNodes\Example.QueryRestrainedNodes.csproj", "{01B24E1B-D201-4F5C-A49C-FFE02DFD3CB9}"
 EndProject
@@ -18,6 +18,10 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Example.QuickStart", "Example.QuickStart\Example.QuickStart.csproj", "{81179620-83D4-469A-B91F-410641200D22}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Example.GeodesicDome", "Example.GeodesicDome\Example.GeodesicDome.csproj", "{56D17B3C-0CFE-4DBF-B0DD-CF41A2065C62}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Example.CreateSimplePlate", "Example.CreateSimplePlate\Example.CreateSimplePlate.csproj", "{75CE69F6-7D44-4AE6-8B68-86D75669B234}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Example.CreateSinglePlate", "Example.CreateSinglePlate\Example.CreateSinglePlate.csproj", "{36D1ACF4-662A-DE28-972E-F1EA40CE48F7}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -53,7 +57,7 @@ Global
 		{C7804F4F-E114-465E-9B1E-0F15221BAB6B}.Release|x64.Build.0 = Release|Any CPU
 		{C7804F4F-E114-465E-9B1E-0F15221BAB6B}.Release|x86.ActiveCfg = Release|Any CPU
 		{C7804F4F-E114-465E-9B1E-0F15221BAB6B}.Release|x86.Build.0 = Release|Any CPU
-{1E37C4AF-EAD8-4471-8388-DA72FE5256D9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1E37C4AF-EAD8-4471-8388-DA72FE5256D9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{1E37C4AF-EAD8-4471-8388-DA72FE5256D9}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{1E37C4AF-EAD8-4471-8388-DA72FE5256D9}.Debug|x64.ActiveCfg = Debug|Any CPU
 		{1E37C4AF-EAD8-4471-8388-DA72FE5256D9}.Debug|x64.Build.0 = Debug|Any CPU
@@ -125,6 +129,30 @@ Global
 		{56D17B3C-0CFE-4DBF-B0DD-CF41A2065C62}.Release|x64.Build.0 = Release|Any CPU
 		{56D17B3C-0CFE-4DBF-B0DD-CF41A2065C62}.Release|x86.ActiveCfg = Release|Any CPU
 		{56D17B3C-0CFE-4DBF-B0DD-CF41A2065C62}.Release|x86.Build.0 = Release|Any CPU
+		{75CE69F6-7D44-4AE6-8B68-86D75669B234}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{75CE69F6-7D44-4AE6-8B68-86D75669B234}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{75CE69F6-7D44-4AE6-8B68-86D75669B234}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{75CE69F6-7D44-4AE6-8B68-86D75669B234}.Debug|x64.Build.0 = Debug|Any CPU
+		{75CE69F6-7D44-4AE6-8B68-86D75669B234}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{75CE69F6-7D44-4AE6-8B68-86D75669B234}.Debug|x86.Build.0 = Debug|Any CPU
+		{75CE69F6-7D44-4AE6-8B68-86D75669B234}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{75CE69F6-7D44-4AE6-8B68-86D75669B234}.Release|Any CPU.Build.0 = Release|Any CPU
+		{75CE69F6-7D44-4AE6-8B68-86D75669B234}.Release|x64.ActiveCfg = Release|Any CPU
+		{75CE69F6-7D44-4AE6-8B68-86D75669B234}.Release|x64.Build.0 = Release|Any CPU
+		{75CE69F6-7D44-4AE6-8B68-86D75669B234}.Release|x86.ActiveCfg = Release|Any CPU
+		{75CE69F6-7D44-4AE6-8B68-86D75669B234}.Release|x86.Build.0 = Release|Any CPU
+		{36D1ACF4-662A-DE28-972E-F1EA40CE48F7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{36D1ACF4-662A-DE28-972E-F1EA40CE48F7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{36D1ACF4-662A-DE28-972E-F1EA40CE48F7}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{36D1ACF4-662A-DE28-972E-F1EA40CE48F7}.Debug|x64.Build.0 = Debug|Any CPU
+		{36D1ACF4-662A-DE28-972E-F1EA40CE48F7}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{36D1ACF4-662A-DE28-972E-F1EA40CE48F7}.Debug|x86.Build.0 = Debug|Any CPU
+		{36D1ACF4-662A-DE28-972E-F1EA40CE48F7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{36D1ACF4-662A-DE28-972E-F1EA40CE48F7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{36D1ACF4-662A-DE28-972E-F1EA40CE48F7}.Release|x64.ActiveCfg = Release|Any CPU
+		{36D1ACF4-662A-DE28-972E-F1EA40CE48F7}.Release|x64.Build.0 = Release|Any CPU
+		{36D1ACF4-662A-DE28-972E-F1EA40CE48F7}.Release|x86.ActiveCfg = Release|Any CPU
+		{36D1ACF4-662A-DE28-972E-F1EA40CE48F7}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/sdks/python/client/space_gass_api/utils/__init__.py
+++ b/sdks/python/client/space_gass_api/utils/__init__.py
@@ -1,0 +1,5 @@
+"""Hand-maintained utility helpers for the SPACE GASS API SDK."""
+
+from .list_utils import to_filter_string, to_id_list
+
+__all__ = ["to_filter_string", "to_id_list"]

--- a/sdks/python/client/space_gass_api/utils/list_utils.py
+++ b/sdks/python/client/space_gass_api/utils/list_utils.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+
+def to_filter_string(ids: Iterable[int] | None) -> str:
+    """Convert a collection of integer IDs to a compact SPACE GASS filter string.
+
+    Non-positive values are ignored. The output is sorted and deduplicated.
+    Runs of 3+ consecutive values collapse to ranges (e.g. ``[3,4,5]`` → ``"3-5"``).
+
+    Examples:
+        >>> to_filter_string([1, 3, 4, 5, 6, 7, 10])
+        '1,3-7,10'
+        >>> to_filter_string([5, 1, 5, 3, 1])
+        '1,3,5'
+        >>> to_filter_string([])
+        ''
+    """
+    if ids is None:
+        return ""
+
+    sorted_ids = sorted(set(id_ for id_ in ids if id_ > 0))
+    if not sorted_ids:
+        return ""
+
+    segments: list[str] = []
+    run_start = sorted_ids[0]
+    run_end = sorted_ids[0]
+
+    for id_ in sorted_ids[1:]:
+        if id_ == run_end + 1:
+            run_end = id_
+        else:
+            _append_run(segments, run_start, run_end)
+            run_start = id_
+            run_end = id_
+
+    _append_run(segments, run_start, run_end)
+    return ",".join(segments)
+
+
+def to_id_list(filter_str: str | None) -> list[int]:
+    """Parse a SPACE GASS filter string into a sorted, distinct list of positive integers.
+
+    Ranges like ``"3-7"`` expand to all values in the inclusive range.
+    Reversed ranges like ``"7-3"`` are normalised.
+    Whitespace around tokens is tolerated.
+
+    Raises:
+        ValueError: If the string contains non-numeric characters, non-positive
+            values, or the keyword ``"all"``.
+
+    Examples:
+        >>> to_id_list('1,3-7,10')
+        [1, 3, 4, 5, 6, 7, 10]
+        >>> to_id_list(' 1 , 3 - 7 ')
+        [1, 3, 4, 5, 6, 7]
+        >>> to_id_list('')
+        []
+    """
+    if not filter_str or not filter_str.strip():
+        return []
+
+    result: list[int] = []
+
+    for raw in filter_str.split(","):
+        token = raw.strip()
+        if not token:
+            continue
+
+        if token.lower() == "all":
+            raise ValueError('The keyword "all" is not a valid ID list.')
+
+        if "-" in token:
+            dash_idx = token.index("-")
+            if dash_idx == 0:
+                raise ValueError(f'Invalid token in ID list: "{token}".')
+
+            start_str = token[:dash_idx].strip()
+            end_str = token[dash_idx + 1 :].strip()
+
+            try:
+                start = int(start_str)
+                end = int(end_str)
+            except ValueError:
+                raise ValueError(f'Invalid token in ID list: "{token}".')
+
+            lo, hi = min(start, end), max(start, end)
+            result.extend(range(lo, hi + 1))
+        else:
+            try:
+                result.append(int(token))
+            except ValueError:
+                raise ValueError(f'Invalid token in ID list: "{token}".')
+
+    sorted_ids = sorted(set(result))
+
+    for id_ in sorted_ids:
+        if id_ <= 0:
+            raise ValueError(f'Non-positive ID "{id_}" is not valid.')
+
+    return sorted_ids
+
+
+def _append_run(segments: list[str], start: int, end: int) -> None:
+    if end - start >= 2:
+        segments.append(f"{start}-{end}")
+    elif end - start == 1:
+        segments.append(f"{start},{end}")
+    else:
+        segments.append(str(start))

--- a/sdks/python/examples/create_simple_beam/create_simple_beam.py
+++ b/sdks/python/examples/create_simple_beam/create_simple_beam.py
@@ -33,6 +33,7 @@ import winreg
 
 from space_gass_api import SpaceGassApiClient
 import space_gass_api.models as models
+from space_gass_api.utils import to_filter_string
 
 # -- Configuration ------------------------------------------------
 with winreg.OpenKey(winreg.HKEY_CURRENT_USER,
@@ -263,7 +264,7 @@ async def main() -> int:
         # == Step 15 — Query reactions =================================
         print("Querying ULS reactions...")
         reactions = await client.job.query.analysis.static.node_reactions.get(
-            cases=str(uls_case.id),
+            cases=to_filter_string([uls_case.id]),
         )
 
         if reactions.warnings and reactions.warnings.cases_not_analyzed:
@@ -279,8 +280,8 @@ async def main() -> int:
 
         # == Step 16 — Maximum ULS bending moment ======================
         uls_forces = await client.job.query.analysis.static.member_intermediate_forces.get(
-            cases=str(uls_case.id),
-            members=str(member.id),
+            cases=to_filter_string([uls_case.id]),
+            members=to_filter_string([member.id]),
         )
 
         beam_forces = uls_forces.results[0]
@@ -289,8 +290,8 @@ async def main() -> int:
 
         # == Step 17 — Maximum SLS deflection ==========================
         sls_displacements = await client.job.query.analysis.static.member_intermediate_displacements.get(
-            cases=str(sls_case.id),
-            members=str(member.id),
+            cases=to_filter_string([sls_case.id]),
+            members=to_filter_string([member.id]),
         )
 
         beam_displacements = sls_displacements.results[0]

--- a/sdks/python/examples/query_restrained_nodes/query_restrained_nodes.py
+++ b/sdks/python/examples/query_restrained_nodes/query_restrained_nodes.py
@@ -17,6 +17,7 @@ import sys
 
 from space_gass_api import SpaceGassApiClient
 import space_gass_api.models as models
+from space_gass_api.utils import to_filter_string
 
 # -- Configuration ------------------------------------------------
 # Update this path to match your local environment.
@@ -55,8 +56,7 @@ async def main() -> int:
             print()
             print("Retrieving reactions for restrained nodes...")
 
-            # Nodes filter uses SG list format (e.g. "1,5-10") — comma-separated Ids works for an arbitrary set.
-            node_filter = ",".join(str(n.id) for n in restrained_nodes if n.id is not None)
+            node_filter = to_filter_string(n.id for n in restrained_nodes if n.id is not None)
 
             reaction_result = await client.job.query.analysis.static.node_reactions.get(
                 nodes=node_filter,


### PR DESCRIPTION
## Summary
- Add `CreateSimplePlate` and `CreateSinglePlate` C# examples
- Add `ListUtils` client helpers (C# and Python) for converting between `int[]` and the SG filter string format (`"1,3-7,10"`)
- Update all existing examples to use the new helpers instead of manual `string.Join` / `str()` construction
- Target `netstandard2.0` + `netstandard2.1` for broader compatibility
## Test plan
- [x] All C# examples build with zero warnings
- [ ] Run plate examples against a local SPACE GASS API instance
- [ ] Verify `ToFilterString()` / `to_filter_string()` round-trips match server-side `ListParser` behaviour