### PR TITLE
Fix docs tab title and update spec to 14.50.108

### DIFF
--- a/descriptions/preview/SpaceGassApi.json
+++ b/descriptions/preview/SpaceGassApi.json
@@ -13,7 +13,7 @@
       "url": "https://www.spacegass.com/manual/Introduction/End_User_Licence_Agreement.htm"
     },
     "version": "1",
-    "x-space-gass-build": "14.50.107"
+    "x-space-gass-build": "14.50.108"
   },
   "servers": [
     {

--- a/docs/zudoku.config.tsx
+++ b/docs/zudoku.config.tsx
@@ -244,7 +244,7 @@ const config: ZudokuConfig = {
     },
   },
   metadata: {
-    title: "SpaceGass API Documentation",
+    title: "SPACE GASS API Documentation",
     description:
       "Programmatic access to SPACE GASS structural analysis data",
     favicon: "/docs/blue-sg-256-clear-bg.ico",


### PR DESCRIPTION
Correct the browser tab title to SPACE GASS API Documentation and bump the OpenAPI spec build version to 14.50.108.