### PR TITLE
Harden CI: pin GitHub Actions to commit SHAs + add Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# Dependabot configuration.
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+#
+# The workflows pin actions to commit SHAs (immutable, hijack-proof). Dependabot
+# keeps those SHAs current by opening update PRs, with a 7-day cooldown so a
+# freshly published (possibly compromised) release has time to be caught and
+# yanked before we adopt it. Security/CVE updates bypass the cooldown.
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -21,12 +21,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "22"
 
@@ -42,7 +42,7 @@ jobs:
         run: cp docs/dist/404.html docs/dist/docs/404.html 2>/dev/null || true
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4.0.0
         with:
           path: docs/dist/docs
 
@@ -55,4 +55,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/generate-clients.yml
+++ b/.github/workflows/generate-clients.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Patch spec — make optional requestBody.required explicit
         run: |

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -15,7 +15,7 @@ jobs:
       pypi-version: ${{ steps.version.outputs.pypi }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Resolve versions from spec and release tag
         id: version
@@ -62,10 +62,10 @@ jobs:
     environment: publish
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
         with:
           dotnet-version: "8.0.x"
 
@@ -91,10 +91,10 @@ jobs:
     environment: publish
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.12"
 


### PR DESCRIPTION
## What

Pins every GitHub Actions reference in this repo's workflows to an immutable commit SHA (with a version comment), and adds a Dependabot config to keep those pins current.

## Why

Action version tags like `@v4` are mutable — the maintainer (or anyone who compromises their account) can repoint a tag to malicious code, which CI then runs automatically with this repo's secrets. This is the mechanism behind the tj-actions/changed-files compromise (CVE-2025-30066). A full commit SHA is content-addressed and cannot be repointed, so the workflow always runs exactly the reviewed code.

## Changes

Pinned (active workflow steps only — the commented-out `test-examples` block is untouched):

| Action | SHA | Version |
| --- | --- | --- |
| actions/checkout | `34e114876b0b11c390a56381ad16ebd13914f8d5` | v4.3.1 |
| actions/setup-node | `49933ea5288caeca8642d1e84afbd3f7d6820020` | v4.4.0 |
| actions/upload-pages-artifact | `7b1f4a764d45c48632c6b24a0339c27f5614fb0b` | v4.0.0 |
| actions/deploy-pages | `cd2ce8fcbc39b97be8ca5fce6e763baed58fa128` | v5.0.0 |
| actions/setup-dotnet | `67a3573c9a986a3f9c594539f4ab511d57bb3ce9` | v4.3.1 |
| actions/setup-python | `a26af69be951a213d495a4c3e4e4022e16d87065` | v5.6.0 |

Added `.github/dependabot.yml` (github-actions, weekly, 7-day cooldown) so the SHAs are kept current automatically; security/CVE updates bypass the cooldown.

## Note

Pinning to the current resolved SHA is behaviour-preserving — these are the exact commits the tags already pointed to, so no workflow behaviour changes. Only future auto-following of tags is frozen (now mediated by Dependabot).

Separately, GitHub reports 14 existing Dependabot vulnerability alerts on `main` (SDK dependencies) — out of scope here but worth triaging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)