### PR TITLE
docs: make the SPACE GASS API discoverable and usable by AI coding agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,90 @@
+# AGENTS.md — SPACE GASS API
+
+Instructions for AI coding agents writing scripts against the SPACE GASS API and its SDKs.
+This is a cross-tool convention (read by many coding agents). Claude Code reads it via the
+import in [CLAUDE.md](CLAUDE.md).
+
+## What this API is
+
+- **SPACE GASS** is structural-analysis software. This API gives programmatic access to it:
+  open/create job files, read and edit structural entities (nodes, members, sections,
+  materials, loads), run analyses, and query results.
+- It is a **headless LOCAL service** — a server running on the user's own machine. There is
+  **no cloud**, **no UI automation**, and **no authentication**.
+- Default base URL: `http://localhost:34560`. The SDK auto-appends `/api/v1`, so you never
+  write the version segment yourself. Either HTTP or HTTPS works; SSL verification is off by
+  default (the local service may use a self-signed cert).
+- The service must be running before any call. It ships as the **SPACE GASS API** shortcut
+  (`SpaceGassApi.exe`).
+
+## Install
+
+```bash
+pip install space-gass-api          # Python 3.9+
+dotnet add package SpaceGassApi     # C# / .NET Standard 2.0+
+```
+
+## Minimal usage
+
+The SDKs are generated with [Microsoft Kiota](https://learn.microsoft.com/en-us/openapi/kiota/),
+so calls are fluent builder chains that end in the HTTP verb (`get`/`post`/`patch`/`delete`).
+Everything is async.
+
+**Python**
+
+```python
+from space_gass_api import SpaceGassApiClient
+import space_gass_api.models as models
+
+client = SpaceGassApiClient.create_client()          # no auth; base URL defaults to localhost:34560
+try:
+    await client.job.open_sample.post(models.OpenSampleRequest(file_name="Portal Frame.SG"))
+    nodes = await client.job.structure.nodes.get()
+    for n in nodes:
+        print(n.id, n.x, n.y, n.z)
+finally:
+    await client.job.close.post()                    # always release the active job
+```
+
+**C#**
+
+```csharp
+using SpaceGassApi;
+using SpaceGassApi.Models;
+
+var client = SpaceGassApiClient.CreateClient();       // no auth; defaults to localhost:34560
+try
+{
+    await client.Job.OpenSample.PostAsync(new OpenSampleRequest { FileName = "Portal Frame.SG" });
+    var nodes = await client.Job.Structure.Nodes.GetAsync();
+    foreach (var n in nodes!) Console.WriteLine($"{n.Id}: ({n.X},{n.Y},{n.Z})");
+}
+finally { await client.Job.Close.PostAsync(); }
+```
+
+## Rules an agent must follow
+
+1. **One active job.** Open a file (`job.open` / `job.open_sample`) or create one before touching
+   structure or results, and `job.close` when done (use `try/finally`). There is a single active
+   job per service instance.
+2. **Analyses are asynchronous.** Start a run (e.g. `job.analysis.static.run_linear.post(...)`),
+   then poll `job.analysis.runs.by_run_id(runId).get()` until `status` is `Completed`, `Failed`,
+   or `Cancelled`. Do not assume results exist immediately after starting a run.
+3. **Never hand-edit generated code.** Files under `sdks/csharp/client/SpaceGassApi/Generated/`
+   and `sdks/python/client/space_gass_api/generated/` are Kiota output and are overwritten.
+4. **Python `.get()` takes keyword query params** — e.g. `client.job.structure.nodes.get(node_type=models.NodeTypeFilter.Restrained)`. Names are the snake_case query-parameter fields.
+5. **Filtering by ID lists** uses the SG list-string format (e.g. `"1-5,8,10"`). C# helpers in
+   `Utils/ListUtilsExtensions.cs` (`ToFilterString`, `ToIdArray`) convert to/from `int[]`.
+6. **File uploads** (`job/new-from-template`, `job/import/txt`) use the multipart helpers
+   `NewFromTemplateRequest` / `ImportTxtRequest`, which take a file path.
+
+## Authoritative resources (fetch these; don't crawl the repo)
+
+- **Full docs bundle for LLMs:** <https://api.spacegass.com/docs/llms-full.txt>
+- **Docs index:** <https://api.spacegass.com/docs/llms.txt>
+- **OpenAPI spec (JSON):** <https://api.spacegass.com/docs/api/1/schema.json>
+- **Docs site:** <https://api.spacegass.com/docs/>
+- **Repo as an MCP server (search docs/examples/code):** <https://gitmcp.io/SpaceGass/space-gass-api>
+- **Runnable examples:** [`sdks/python/examples/`](sdks/python/examples/) · [`sdks/csharp/examples/`](sdks/csharp/examples/)
+
+When fetching individual repo files, use `raw.githubusercontent.com/...` URLs, **never** `github.com/.../blob/...` (those return an HTML page, not the file), and prefer the bundle URLs above so you never need to crawl the repo tree.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,12 @@ Project context and decisions for the `space-gass-api` repository.
 
 This is the public developer-facing repo for the SPACE GASS API. It contains the OpenAPI spec, auto-generated Kiota SDKs, hand-crafted examples, and a Zudoku documentation site deployed to GitHub Pages.
 
+### Agent-facing SDK usage
+
+Cross-tool agent instructions (install, `CreateClient()`, base URL, async/analysis rules, key resources) live in `AGENTS.md` at the repo root — imported below so Claude Code loads it too. Keep SDK *usage* guidance in `AGENTS.md`; keep repo *maintenance* decisions in this file.
+
+@AGENTS.md
+
 ## Key Decisions
 
 ### Branching

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 Spacegass
+Copyright (c) 2026 Space Gass Pty Ltd
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -80,6 +80,32 @@ finally:
 
 For the full walk-through see the [Quick Start](https://api.spacegass.com/docs/getting-started/quick-start). More examples are in `sdks/csharp/examples/` and `sdks/python/examples/`, or clone the repo and browse.
 
+## Using with AI coding agents
+
+Writing scripts against this API with an AI assistant (Claude Code, Cursor, Copilot, ChatGPT, etc.)? Point the agent at the resources below rather than letting it crawl this repo — the docs bundle and OpenAPI spec are single, clean, machine-readable fetches.
+
+- **Full docs bundle for LLMs:** <https://api.spacegass.com/docs/llms-full.txt>
+- **Docs index:** <https://api.spacegass.com/docs/llms.txt>
+- **OpenAPI spec (JSON):** <https://api.spacegass.com/docs/api/1/schema.json>
+- **This repo as an MCP server** (lets an agent search the docs, examples, and code with zero setup): <https://gitmcp.io/SpaceGass/space-gass-api>
+- **Repo-root agent instructions:** [`AGENTS.md`](AGENTS.md)
+
+Paste this to prime an agent:
+
+```
+You have access to the SPACE GASS structural-analysis API — a LOCAL, no-auth
+service at http://localhost:34560 (base path /api/v1). Load these first:
+- Full docs bundle:  https://api.spacegass.com/docs/llms-full.txt
+- OpenAPI spec:      https://api.spacegass.com/docs/api/1/schema.json
+- Repo via GitMCP:   https://gitmcp.io/SpaceGass/space-gass-api
+
+SDKs (Kiota, fluent builder chains, async):
+- Python:  pip install space-gass-api    ->  from space_gass_api import SpaceGassApiClient
+- C#:      dotnet add package SpaceGassApi
+Both expose SpaceGassApiClient.CreateClient() (no auth, base URL auto-set).
+Use raw.githubusercontent.com for repo files, never /blob/ URLs.
+```
+
 ## Descriptions & Client Generation
 
 The C# and Python SDKs are auto-generated using [Kiota](https://learn.microsoft.com/en-us/openapi/kiota/) from the current spec (`descriptions/current/`). Previously released specs are kept in `descriptions/archive/` for reference.

--- a/context7.json
+++ b/context7.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://context7.com/schema/context7.json",
+  "projectTitle": "SPACE GASS API",
+  "description": "Programmatic access to SPACE GASS structural analysis. Local, no-auth HTTP service (http://localhost:34560, base path /api/v1) with generated C# (SpaceGassApi) and Python (space-gass-api) SDKs.",
+  "folders": [
+    "docs/pages",
+    "descriptions/preview",
+    "sdks/python/examples",
+    "sdks/csharp/examples"
+  ],
+  "excludeFolders": [
+    "docs/node_modules",
+    "docs/dist",
+    "sdks/csharp/client/SpaceGassApi/Generated",
+    "sdks/python/client/space_gass_api/generated"
+  ],
+  "rules": [
+    "The SPACE GASS API is a local, no-auth HTTP service at http://localhost:34560; the SDK appends /api/v1 automatically.",
+    "Create the client with SpaceGassApiClient.CreateClient() (C#) or SpaceGassApiClient.create_client() (Python). No API key is required.",
+    "There is a single active job per service instance: open or create a job before touching structure or results, and close it when done (try/finally).",
+    "Analyses are asynchronous: start a run, then poll job/analysis/runs/{runId} until status is Completed, Failed, or Cancelled.",
+    "Never hand-edit files under Generated/ (C#) or generated/ (Python) — they are Kiota-generated output."
+  ]
+}

--- a/docs/pages/examples/reactions-for-restrained-nodes.mdx
+++ b/docs/pages/examples/reactions-for-restrained-nodes.mdx
@@ -120,8 +120,8 @@ curl "http://localhost:34560/api/v1/job/query/analysis/static/node-reactions?nod
 
 The same code (against your own .sg file rather than the sample) is
 in the repo as
-[`Example.QueryRestrainedNodes`](https://github.com/Spacegass/space-gass-api/tree/develop/sdks/csharp/examples/Example.QueryRestrainedNodes) (C#) and
-[`query_restrained_nodes`](https://github.com/Spacegass/space-gass-api/tree/develop/sdks/python/examples/query_restrained_nodes) (Python).
+[`Example.QueryRestrainedNodes`](https://github.com/SpaceGass/space-gass-api/tree/main/sdks/csharp/examples/Example.QueryRestrainedNodes) (C#) and
+[`query_restrained_nodes`](https://github.com/SpaceGass/space-gass-api/tree/main/sdks/python/examples/query_restrained_nodes) (Python).
 Clone and run:
 
 <CodeTabs>

--- a/docs/pages/examples/run-linear-static-analysis.mdx
+++ b/docs/pages/examples/run-linear-static-analysis.mdx
@@ -83,8 +83,8 @@ finally:
 
 A richer version with progress polling, a reusable `WaitForCompletion`
 helper, and a result summary is in the repo as
-[`Example.RunAnalysis`](https://github.com/Spacegass/space-gass-api/tree/develop/sdks/csharp/examples/Example.RunAnalysis) (C#) and
-[`run_analysis`](https://github.com/Spacegass/space-gass-api/tree/develop/sdks/python/examples/run_analysis) (Python).
+[`Example.RunAnalysis`](https://github.com/SpaceGass/space-gass-api/tree/main/sdks/csharp/examples/Example.RunAnalysis) (C#) and
+[`run_analysis`](https://github.com/SpaceGass/space-gass-api/tree/main/sdks/python/examples/run_analysis) (Python).
 Clone and run:
 
 <CodeTabs>

--- a/docs/pages/examples/simple-beam.mdx
+++ b/docs/pages/examples/simple-beam.mdx
@@ -782,8 +782,8 @@ finally:
 ## Run this example locally
 
 The complete program with error handling is in the repo as
-[`Example.CreateSimpleBeam`](https://github.com/Spacegass/space-gass-api/tree/develop/sdks/csharp/examples/Example.CreateSimpleBeam) (C#) and
-[`create_simple_beam`](https://github.com/Spacegass/space-gass-api/tree/develop/sdks/python/examples/create_simple_beam) (Python).
+[`Example.CreateSimpleBeam`](https://github.com/SpaceGass/space-gass-api/tree/main/sdks/csharp/examples/Example.CreateSimpleBeam) (C#) and
+[`create_simple_beam`](https://github.com/SpaceGass/space-gass-api/tree/main/sdks/python/examples/create_simple_beam) (Python).
 Clone the repo and run it directly — no copy-paste:
 
 <CodeTabs>

--- a/docs/pages/guides/running-analysis.mdx
+++ b/docs/pages/guides/running-analysis.mdx
@@ -418,5 +418,5 @@ solver has stopped.
 For a full example of an interactive monitoring application that
 tracks multiple concurrent runs with live progress bars, elapsed
 timers, and error/warning display, see the
-[AnalysisMonitor WPF example](https://github.com/Spacegass/space-gass-api/tree/develop/sdks/csharp/examples/Example.AnalysisMonitor)
+[AnalysisMonitor WPF example](https://github.com/SpaceGass/space-gass-api/tree/main/sdks/csharp/examples/Example.AnalysisMonitor)
 in the repository.

--- a/docs/pages/guides/service-automation.mdx
+++ b/docs/pages/guides/service-automation.mdx
@@ -261,8 +261,8 @@ signal.signal(signal.SIGTERM, _shutdown)
 
 The complete program with error handling and Ctrl+C wiring is in the
 repo as
-[`Example.ServiceAutomation`](https://github.com/Spacegass/space-gass-api/tree/develop/sdks/csharp/examples/Example.ServiceAutomation) (C#) and
-[`service_automation`](https://github.com/Spacegass/space-gass-api/tree/develop/sdks/python/examples/service_automation) (Python).
+[`Example.ServiceAutomation`](https://github.com/SpaceGass/space-gass-api/tree/main/sdks/csharp/examples/Example.ServiceAutomation) (C#) and
+[`service_automation`](https://github.com/SpaceGass/space-gass-api/tree/main/sdks/python/examples/service_automation) (Python).
 Clone the repo and run it directly — no copy-paste:
 
 <CodeTabs>

--- a/docs/pages/overview.mdx
+++ b/docs/pages/overview.mdx
@@ -59,6 +59,17 @@ The machine-readable spec is published at
 [`api/1/schema.json`](https://api.spacegass.com/docs/api/1/schema.json)
 if you want to generate a client for another language or feed it to an LLM.
 
+## Using with AI coding agents
+
+Building scripts with an AI assistant (Claude Code, Cursor, Copilot, ChatGPT)?
+Point it at these single, clean, machine-readable entry points instead of
+letting it crawl the source repo:
+
+- **Full docs bundle for LLMs:** [`llms-full.txt`](https://api.spacegass.com/docs/llms-full.txt)
+- **OpenAPI spec (JSON):** [`api/1/schema.json`](https://api.spacegass.com/docs/api/1/schema.json)
+- **Repo as an MCP server** (search docs, examples, and code with zero setup):
+  [`gitmcp.io/SpaceGass/space-gass-api`](https://gitmcp.io/SpaceGass/space-gass-api)
+
 ## Next Steps
 
 - [Quick Start](/quick-start) — Get up and running

--- a/docs/pages/quick-start.mdx
+++ b/docs/pages/quick-start.mdx
@@ -259,8 +259,8 @@ curl -X POST http://localhost:34560/api/v1/job/close
 ## Run this example locally
 
 The same code is in the repo as
-[`Example.QuickStart`](https://github.com/Spacegass/space-gass-api/tree/develop/sdks/csharp/examples/Example.QuickStart) (C#) and
-[`quick_start`](https://github.com/Spacegass/space-gass-api/tree/develop/sdks/python/examples/quick_start) (Python).
+[`Example.QuickStart`](https://github.com/SpaceGass/space-gass-api/tree/main/sdks/csharp/examples/Example.QuickStart) (C#) and
+[`quick_start`](https://github.com/SpaceGass/space-gass-api/tree/main/sdks/python/examples/quick_start) (Python).
 Clone the repo and run it directly — no copy-paste:
 
 <CodeTabs>

--- a/docs/public/robots.txt
+++ b/docs/public/robots.txt
@@ -1,0 +1,37 @@
+# SPACE GASS API — robots.txt
+# Served at https://api.spacegass.com/robots.txt (see Azure Front Door routing).
+# AI crawlers and documentation agents are explicitly welcome.
+
+User-agent: *
+Allow: /
+
+# Named AI / agent crawlers (explicit allow so access is unambiguous)
+User-agent: GPTBot
+Allow: /
+
+User-agent: OAI-SearchBot
+Allow: /
+
+User-agent: ChatGPT-User
+Allow: /
+
+User-agent: ClaudeBot
+Allow: /
+
+User-agent: Claude-User
+Allow: /
+
+User-agent: Claude-SearchBot
+Allow: /
+
+User-agent: PerplexityBot
+Allow: /
+
+User-agent: Google-Extended
+Allow: /
+
+# LLM-friendly entry points:
+#   https://api.spacegass.com/llms.txt
+#   https://api.spacegass.com/llms-full.txt
+
+Sitemap: https://api.spacegass.com/sitemap.xml

--- a/docs/zudoku.config.tsx
+++ b/docs/zudoku.config.tsx
@@ -439,6 +439,14 @@ const config: ZudokuConfig = {
     //   options: { ... },
     // },
   ],
+  // Generates sitemap.xml at build time into the deploy artifact (dist/docs/sitemap.xml,
+  // served at /docs/sitemap.xml). Azure Front Door rewrites the apex /sitemap.xml to it.
+  // Entries are absolute: siteUrl + basePath + page (e.g. https://api.spacegass.com/docs/quick-start).
+  sitemap: {
+    siteUrl: "https://api.spacegass.com",
+    changefreq: "weekly",
+    priority: 0.7,
+  },
   search: {
     type: "pagefind",
   },

--- a/docs/zudoku.config.tsx
+++ b/docs/zudoku.config.tsx
@@ -183,7 +183,7 @@ const config: ZudokuConfig = {
     "head-navigation-end": (
       <div style={{ display: "flex", alignItems: "center", gap: "4px" }}>
         <a
-          href="https://github.com/Spacegass/space-gass-api"
+          href="https://github.com/SpaceGass/space-gass-api"
           target="_blank"
           rel="noopener noreferrer"
           title="GitHub"
@@ -464,7 +464,7 @@ const config: ZudokuConfig = {
     },
     defaultOptions: {
       suggestEdit: {
-        url: "https://github.com/Spacegass/space-gass-api/edit/main/docs/pages",
+        url: "https://github.com/SpaceGass/space-gass-api/edit/main/docs/pages",
       },
     },
   },

--- a/sdks/csharp/client/SpaceGassApi/README.md
+++ b/sdks/csharp/client/SpaceGassApi/README.md
@@ -2,25 +2,25 @@
 
 Official .NET SDK for the SPACE GASS API.
 
-The SPACE GASS API gives you programmatic access to SPACE GASS structural analysis — open or create job files, build and edit structural models, run analyses, and query results. The API runs as a local service on your machine with no authentication required.
+The SPACE GASS API gives you programmatic access to SPACE GASS structural analysis — open or create job files, build and edit structural models, run analyses, and query results. The API runs as a **local service** on your machine with **no authentication**.
 
-## Compatibility
+## Install
 
-- Targets **.NET Standard 2.0** and **.NET Standard 2.1**
-- .NET Framework 4.6.1+, .NET Core 2.0+, .NET 5+, .NET 6+, .NET 8+
+```bash
+dotnet add package SpaceGassApi
+```
 
-## Prerequisites
-
+- Targets **.NET Standard 2.0** and **2.1** (.NET Framework 4.6.1+, .NET Core 2.0+, .NET 5/6/8+)
 - [SPACE GASS](https://www.spacegass.com) installed with an active licence
 - The SPACE GASS API service running locally (default: `http://localhost:34560`)
 
-## Quick Start
+## Quick start
 
 ```csharp
 using SpaceGassApi;
 using SpaceGassApi.Models;
 
-var client = SpaceGassApiClient.CreateClient();
+var client = SpaceGassApiClient.CreateClient();   // no auth; defaults to http://localhost:34560
 
 try
 {
@@ -32,19 +32,14 @@ try
     var nodes = await client.Job.Structure.Nodes.GetAsync();
     foreach (var n in nodes!)
         Console.WriteLine($"Node {n.Id}: ({n.X}, {n.Y}, {n.Z})");
-
-    // List all members
-    var members = await client.Job.Structure.Members.GetAsync();
-    foreach (var m in members!)
-        Console.WriteLine($"Member {m.Id}: Node {m.NodeA} -> Node {m.NodeB}");
 }
 finally
 {
-    await client.Job.Close.PostAsync();
+    await client.Job.Close.PostAsync();           // always release the active job
 }
 ```
 
-## Run an Analysis and Query Results
+## Run an analysis and query results
 
 ```csharp
 var client = SpaceGassApiClient.CreateClient();
@@ -54,11 +49,10 @@ try
     await client.Job.Open.PostAsync(
         new OpenJobRequest { FilePath = @"C:\Models\MyProject.sg" });
 
-    // Run a linear static analysis with current settings
+    // Analyses are asynchronous: start a run, then poll for completion.
     var run = await client.Job.Analysis.Static.RunLinear.PostAsync(
         new StaticSettingsUpdate());
 
-    // Poll until complete
     AnalysisRun result;
     do
     {
@@ -80,8 +74,61 @@ finally
 }
 ```
 
+## How this SDK is structured
+
+Most of this SDK is generated from the OpenAPI specification with
+[Microsoft Kiota](https://learn.microsoft.com/en-us/openapi/kiota/). Every endpoint is a
+**fluent builder chain that ends in the HTTP verb** — `await client.Job.Structure.Nodes.GetAsync()`,
+`...PostAsync(body)`, `...PatchAsync(body)`, `...DeleteAsync()`. Path parameters use indexers
+(e.g. `client.Job.Analysis.Runs[runId]`). If an endpoint isn't shown in these examples, the same
+pattern applies — browse the [API Reference](https://api.spacegass.com/docs/api).
+
+On top of the generated client, a few **hand-written conveniences** (below) smooth the rough
+edges. Everything not listed there is standard Kiota.
+
+## Conveniences on top of Kiota
+
+**`SpaceGassApiClient.CreateClient(baseUrl)`** — one-line factory. Configures anonymous auth,
+appends `/api/v1` to the base URL, disables SSL verification (the local service may use a
+self-signed certificate), allows HTTP↔HTTPS redirects, and sets a long timeout for analyses.
+Pass `baseUrl` only if the service runs on a non-default port (use `https://` for HTTPS).
+
+**ID-list filter helpers** (`SpaceGassApi.Utils`) — convert between `int` collections and the
+compact SPACE GASS filter-string format (`"1,3-7,10"`) used by query parameters:
+
+```csharp
+using SpaceGassApi.Utils;
+
+// int collection -> compact filter string (sorted, de-duplicated, ranges collapsed)
+string filter = new[] { 1, 2, 3, 5, 8 }.ToFilterString();   // "1-3,5,8"
+
+// filter string -> ints (ranges expanded)
+int[] ids = "1-3,5,8".ToIdArray();                          // { 1, 2, 3, 5, 8 }
+List<int> idList = "1-3,5,8".ToIdList();
+```
+
+**File uploads by path** — `NewFromTemplateRequest` / `ImportTxtRequest` wrap the multipart
+upload endpoints so you can pass a file path directly:
+
+```csharp
+await client.Job.NewFromTemplate.PostAsync(
+    new NewFromTemplateRequest(@"C:\Templates\design.sgbase"));
+await client.Job.Import.Txt.PostAsync(
+    new ImportTxtRequest(@"C:\Data\model.txt"));
+```
+
+## Using with an AI assistant
+
+Writing scripts with an AI coding agent? Point it at these single, machine-readable entry
+points rather than letting it crawl the source repo:
+
+- Full docs bundle for LLMs: <https://api.spacegass.com/docs/llms-full.txt>
+- OpenAPI spec (JSON): <https://api.spacegass.com/docs/api/1/schema.json>
+- Repo as an MCP server (search docs, examples, code): <https://gitmcp.io/SpaceGass/space-gass-api>
+
 ## Documentation
 
-- [Getting Started](https://api.spacegass.com/docs/getting-started/quick-start)
+- [Quick Start](https://api.spacegass.com/docs/quick-start)
+- [Concepts](https://api.spacegass.com/docs/concepts)
 - [API Reference](https://api.spacegass.com/docs/api)
-- [Examples](https://github.com/Spacegass/space-gass-api/tree/main/sdks/csharp/examples)
+- [Examples](https://github.com/SpaceGass/space-gass-api/tree/main/sdks/csharp/examples)

--- a/sdks/csharp/client/SpaceGassApi/SpaceGassApi.csproj
+++ b/sdks/csharp/client/SpaceGassApi/SpaceGassApi.csproj
@@ -14,7 +14,7 @@
     <Authors>Space Gass Pty Ltd</Authors>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://api.spacegass.com/docs/</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/Spacegass/space-gass-api</RepositoryUrl>
+    <RepositoryUrl>https://github.com/SpaceGass/space-gass-api</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>spacegass;structural-analysis;api;sdk</PackageTags>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/sdks/python/client/README.md
+++ b/sdks/python/client/README.md
@@ -2,18 +2,19 @@
 
 Official Python SDK for the SPACE GASS API.
 
-The SPACE GASS API gives you programmatic access to SPACE GASS structural analysis — open or create job files, build and edit structural models, run analyses, and query results. The API runs as a local service on your machine with no authentication required.
+The SPACE GASS API gives you programmatic access to SPACE GASS structural analysis — open or create job files, build and edit structural models, run analyses, and query results. The API runs as a **local service** on your machine with **no authentication**.
 
-## Compatibility
+## Install
+
+```bash
+pip install space-gass-api
+```
 
 - Python 3.9+
-
-## Prerequisites
-
 - [SPACE GASS](https://www.spacegass.com) installed with an active licence
 - The SPACE GASS API service running locally (default: `http://localhost:34560`)
 
-## Quick Start
+## Quick start
 
 ```python
 import asyncio
@@ -21,7 +22,7 @@ from space_gass_api import SpaceGassApiClient
 import space_gass_api.models as models
 
 async def main():
-    client = SpaceGassApiClient.create_client()
+    client = SpaceGassApiClient.create_client()   # no auth; defaults to http://localhost:34560
 
     try:
         # Open a built-in sample project
@@ -32,18 +33,13 @@ async def main():
         nodes = await client.job.structure.nodes.get()
         for n in nodes:
             print(f"Node {n.id}: ({n.x}, {n.y}, {n.z})")
-
-        # List all members
-        members = await client.job.structure.members.get()
-        for m in members:
-            print(f"Member {m.id}: Node {m.node_a} -> Node {m.node_b}")
     finally:
-        await client.job.close.post()
+        await client.job.close.post()             # always release the active job
 
 asyncio.run(main())
 ```
 
-## Run an Analysis and Query Results
+## Run an analysis and query results
 
 ```python
 import asyncio
@@ -55,17 +51,15 @@ async def main():
 
     try:
         await client.job.open.post(
-            models.OpenJobRequest(file_name=r"C:\Models\MyProject.sg"))
+            models.OpenJobRequest(file_path=r"C:\Models\MyProject.sg"))
 
-        # Run a linear static analysis with current settings
+        # Analyses are asynchronous: start a run, then poll for completion.
         run = await client.job.analysis.static.run_linear.post(
             models.StaticSettingsUpdate())
 
-        # Poll until complete
         while True:
             await asyncio.sleep(0.5)
-            result = await client.job.analysis.runs.by_run_id(
-                str(run.run_id)).get()
+            result = await client.job.analysis.runs.by_run_id(str(run.run_id)).get()
             if result.status in (
                 models.AnalysisRunStatus.Completed,
                 models.AnalysisRunStatus.Failed,
@@ -83,35 +77,70 @@ async def main():
 asyncio.run(main())
 ```
 
-## Enhanced `.get()` with keyword arguments
+## How this SDK is structured
 
-The SDK enhances Kiota-generated `.get()` methods so you can pass query
-parameters as keyword arguments directly instead of the verbose
-`RequestConfiguration` pattern:
+Most of this SDK is generated from the OpenAPI specification with
+[Microsoft Kiota](https://learn.microsoft.com/en-us/openapi/kiota/). Every endpoint is a
+**fluent builder chain that ends in the HTTP verb** — `await client.job.structure.nodes.get()`,
+`...post(body)`, `...patch(body)`, `...delete()`. Path parameters use `.by_*()` selectors
+(e.g. `client.job.analysis.runs.by_run_id(run_id)`). If an endpoint isn't shown in these
+examples, the same pattern applies — browse the
+[API Reference](https://api.spacegass.com/docs/api).
+
+On top of the generated client, a few **hand-written conveniences** (below) smooth the rough
+edges. Everything not listed there is standard Kiota.
+
+## Conveniences on top of Kiota
+
+**`SpaceGassApiClient.create_client(base_url=...)`** — one-line factory. Configures anonymous
+auth, appends `/api/v1` to the base URL, disables SSL verification (the local service may use a
+self-signed certificate), allows HTTP↔HTTPS redirects, and sets a long timeout for analyses.
+Pass `base_url` only if the service runs on a non-default port (use `https://` for HTTPS).
+
+**Keyword query parameters on `.get()`** — pass query parameters directly instead of the verbose
+`RequestConfiguration` pattern. Names are the snake_case query fields; invalid names raise
+`TypeError`. Fully type-stubbed, so IDE autocomplete works.
 
 ```python
-# Simple — keyword arguments
+# Keyword form (enhanced)
 nodes = await client.job.structure.nodes.get(
     node_type=models.NodeTypeFilter.Restrained)
+reactions = await client.job.query.analysis.static.node_reactions.get(
+    cases="1,3-7", nodes="10-12")     # ID-list filters use the SG format "1,3-7,10"
 
-# Verbose — also supported for advanced use cases
+# Verbose form (still supported for advanced use)
 from kiota_abstractions.base_request_configuration import RequestConfiguration
 from space_gass_api.generated.job.structure.nodes.nodes_request_builder import (
     NodesRequestBuilder,
 )
-
 qp = NodesRequestBuilder.NodesRequestBuilderGetQueryParameters(
     node_type=models.NodeTypeFilter.Restrained)
 nodes = await client.job.structure.nodes.get(
     request_configuration=RequestConfiguration(query_parameters=qp))
 ```
 
-Keyword argument names match the **snake_case field names** on the
-builder's query parameters (e.g. `node_type`, `limit`, `offset`,
-`min_x`). Invalid names raise `TypeError` with a clear message.
+**File uploads by path** — `NewFromTemplateRequest` / `ImportTxtRequest` wrap the multipart
+upload endpoints so you can pass a file path directly:
+
+```python
+from space_gass_api import NewFromTemplateRequest, ImportTxtRequest
+
+await client.job.new_from_template.post(NewFromTemplateRequest("design.sgbase"))
+await client.job.import_.txt.post(ImportTxtRequest("model.txt"))
+```
+
+## Using with an AI assistant
+
+Writing scripts with an AI coding agent? Point it at these single, machine-readable entry
+points rather than letting it crawl the source repo:
+
+- Full docs bundle for LLMs: <https://api.spacegass.com/docs/llms-full.txt>
+- OpenAPI spec (JSON): <https://api.spacegass.com/docs/api/1/schema.json>
+- Repo as an MCP server (search docs, examples, code): <https://gitmcp.io/SpaceGass/space-gass-api>
 
 ## Documentation
 
-- [Getting Started](https://api.spacegass.com/docs/getting-started/quick-start)
+- [Quick Start](https://api.spacegass.com/docs/quick-start)
+- [Concepts](https://api.spacegass.com/docs/concepts)
 - [API Reference](https://api.spacegass.com/docs/api)
-- [Examples](https://github.com/Spacegass/space-gass-api/tree/main/sdks/python/examples)
+- [Examples](https://github.com/SpaceGass/space-gass-api/tree/main/sdks/python/examples)

--- a/sdks/python/client/pyproject.toml
+++ b/sdks/python/client/pyproject.toml
@@ -25,8 +25,8 @@ dependencies = [
 
 [project.urls]
 Documentation = "https://api.spacegass.com/docs/"
-Repository = "https://github.com/Spacegass/space-gass-api"
-Issues = "https://github.com/Spacegass/space-gass-api/issues"
+Repository = "https://github.com/SpaceGass/space-gass-api"
+Issues = "https://github.com/SpaceGass/space-gass-api/issues"
 
 [tool.setuptools.packages.find]
 include = ["space_gass_api*"]


### PR DESCRIPTION
## Summary

Makes the SPACE GASS API resources discoverable and usable by AI coding agents.

The docs content was already agent-consumable (clean `llms.txt`, `.md` page twins,
`schema.json`), but no chatbot was finding it — because `llms.txt` is a *pointer*
standard, not a *discovery* one: nothing auto-fetches it, so agents fell back to
crawling the repo and hit GitHub's unauthenticated rate limits. This PR gets the
API onto the channels agents actually pull docs from, makes the developer handoff
explicit, and fixes a couple of real bugs found along the way.

No runtime or SDK behavior changes — docs, metadata, and discoverability only.

## What's in this PR

**Agent discoverability**
- `AGENTS.md` (new) — repo-root, cross-tool agent instructions: install commands,
  `CreateClient()`, local no-auth base URL, async/one-active-job/analysis rules,
  and authoritative resource URLs. Imported into `CLAUDE.md` via `@AGENTS.md`
  (Claude Code doesn't read `AGENTS.md` natively).
- `README.md` + docs Overview — "Using with AI coding agents" section + a
  paste-able priming snippet (llms-full.txt, OpenAPI spec, GitMCP).
- `context7.json` (new) — scopes Context7 indexing to docs/examples/spec.
- Zudoku `sitemap.xml` generation + `docs/public/robots.txt` welcoming AI
  crawlers and advertising the sitemap. Both serve at `/docs/*`; intended to be
  exposed at the apex via Azure Front Door (see follow-ups).

**Package READMEs (PyPI / NuGet)**
- Hardened both into standalone quickstarts: install command, a "How this SDK is
  structured" note (it's a Kiota client — fluent builders ending in the HTTP
  verb, so readers/agents can generalize), and documentation of the hand-written
  conveniences (`CreateClient()`/`create_client()`, Python keyword query params
  on `.get()`, C# ID-list filter helpers, upload-by-path helpers).
- Fix: `OpenJobRequest(file_name=...)` → `file_path=` in the Python README (the
  model field is `file_path`; the old form raised `TypeError`).

**Cleanup / bug fixes**
- Canonicalize GitHub org URLs: `github.com/Spacegass` → `github.com/SpaceGass`
  across package metadata, the Zudoku config, and docs pages.
- Fix broken example links: docs pages linked to a non-existent `develop` branch
  (`/tree/develop/...` → 404). Repointed to `/tree/main/`; all referenced example
  folders verified present on `origin/main`.
- `LICENSE` copyright holder → `Space Gass Pty Ltd` (was `Spacegass`).

## Verification
- Docs build passes; `sitemap.xml` + `robots.txt` confirmed in the deploy artifact.
- Deployed docs HTML confirmed prerendered (crawler-readable without JS).
- All rewritten example links verified against folders on `origin/main`.

## Follow-ups (not in this PR)
- **Merge → deploy:** `deploy-docs` runs on push to `main`, so robots.txt/sitemap
  and the homepage callout go live only after merge.
- **Azure Front Door:** add URL-rewrite rules so `/robots.txt`, `/sitemap.xml`,
  `/openapi.json` serve at the apex from their `/docs/*` origin paths (spec
  provided to IT separately).
- **Context7:** submit the repo at context7.com/add-library.
- **Package release:** cut a release to propagate the updated READMEs to PyPI/NuGet.