### PR TITLE
Fix broken Python imports in docs; kwargs query params for POST/PATCH/DELETE

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,7 +72,7 @@ finally { await client.Job.Close.PostAsync(); }
    or `Cancelled`. Do not assume results exist immediately after starting a run.
 3. **Never hand-edit generated code.** Files under `sdks/csharp/client/SpaceGassApi/Generated/`
    and `sdks/python/client/space_gass_api/generated/` are Kiota output and are overwritten.
-4. **Python `.get()` takes keyword query params** — e.g. `client.job.structure.nodes.get(node_type=models.NodeTypeFilter.Restrained)`. Names are the snake_case query-parameter fields.
+4. **Python query params are keyword args on the verb call** — e.g. `client.job.structure.nodes.get(node_type=models.NodeTypeFilter.Restrained)` or `client.job.structure.nodes.bulk.post(bodies, continue_on_error=True)`. Works on `get`/`post`/`patch`/`delete` wherever the endpoint defines query parameters; names are the snake_case query-parameter fields.
 5. **Filtering by ID lists** uses the SG list-string format (e.g. `"1-5,8,10"`). C# helpers in
    `Utils/ListUtilsExtensions.cs` (`ToFilterString`, `ToIdArray`) convert to/from `int[]`.
 6. **File uploads** (`job/new-from-template`, `job/import/txt`) use the multipart helpers

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,7 +89,7 @@ sdks/python/client/
 └── space_gass_api/
     ├── __init__.py                 ← AUTO-WRITTEN post-Kiota by tools/regen_python_inits.py
     ├── __init__.pyi                ← AUTO-WRITTEN post-Kiota (type stub for IDE support)
-    ├── space_gass_api_client.py    ← hand-maintained (SpaceGassApiClient, create_client, _enhance_get_methods)
+    ├── space_gass_api_client.py    ← hand-maintained (SpaceGassApiClient, create_client, _enhance_request_methods)
     ├── upload_requests.py          ← hand-maintained (NewFromTemplateRequest, ImportTxtRequest)
     ├── models/
     │   └── __init__.py             ← AUTO-WRITTEN post-Kiota (re-exports from generated/)
@@ -102,7 +102,7 @@ sdks/python/client/
 - Kiota generates `BaseSpaceGassApiClient` (set via `--class-name` in the workflow) into the `generated/` subfolder with namespace `space_gass_api.generated`. The hand-maintained `space_gass_api_client.py` defines `SpaceGassApiClient(BaseSpaceGassApiClient)` which adds `create_client()` as a static method. Same pattern as the [Microsoft Graph Python SDK](https://github.com/microsoftgraph/msgraph-sdk-python).
 - The `generated/` subfolder is the Kiota `--clean-output` target. Hand-maintained files (`__init__.py`, `__init__.pyi`, `space_gass_api_client.py`, `models/__init__.py`) live outside it and survive regeneration.
 - The post-regen script `tools/regen_python_inits.py` writes `__init__.py` at the package root and `models/__init__.py` as a re-export shim so callers can write `from space_gass_api import SpaceGassApiClient` and `import space_gass_api.models as models`.
-- `space_gass_api/__init__.py` imports `SpaceGassApiClient` from the hand-maintained `space_gass_api_client` module and calls `_enhance_get_methods()` to enable `.get(**kwargs)` on builders.
+- `space_gass_api/__init__.py` imports `SpaceGassApiClient` from the hand-maintained `space_gass_api_client` module and calls `_enhance_request_methods()` to enable keyword query parameters on builder `get`/`post`/`patch`/`put`/`delete` methods (each verb is enhanced only where a matching `{Verb}QueryParameters` dataclass exists).
 - **Hand-maintained additions on top of Kiota** (Python mirror of the C# `Utils/` layer) live at the package root, outside `generated/`: `upload_requests.py` defines `NewFromTemplateRequest` / `ImportTxtRequest`, which subclass Kiota's `MultipartBody` so the multipart file-upload endpoints can be called by file path — `await client.job.new_from_template.post(NewFromTemplateRequest(path))`. They are re-exported from the package root by `tools/regen_python_inits.py` (so `from space_gass_api import NewFromTemplateRequest` works); update that script's `PKG_INIT_*` constants when adding more.
 
 ### Authentication

--- a/docs/pages/guides/bulk-operations.mdx
+++ b/docs/pages/guides/bulk-operations.mdx
@@ -84,13 +84,7 @@ Console.WriteLine($"Failed:    {result.Errors!.Count}");
 ```
 
 ```python title="Python"
-from kiota_abstractions.base_request_configuration import RequestConfiguration
-from space_gass_api.job.structure.nodes.bulk.bulk_request_builder import BulkRequestBuilder
-
-params = BulkRequestBuilder.BulkRequestBuilderPostQueryParameters(continue_on_error=True)
-result = await client.job.structure.nodes.bulk.post(
-    bodies,
-    request_configuration=RequestConfiguration(query_parameters=params))
+result = await client.job.structure.nodes.bulk.post(bodies, continue_on_error=True)
 
 print(f"Succeeded: {len(result.succeeded or [])}")
 print(f"Failed:    {len(result.errors or [])}")

--- a/docs/pages/guides/error-handling.mdx
+++ b/docs/pages/guides/error-handling.mdx
@@ -74,7 +74,7 @@ catch (ErrorResponse err)
 ```
 
 ```python title="Python"
-from space_gass_api.models.error_response import ErrorResponse
+from space_gass_api.models import ErrorResponse
 
 try:
     node = await client.job.structure.nodes.by_id(999).get()

--- a/docs/pages/guides/file-handling.mdx
+++ b/docs/pages/guides/file-handling.mdx
@@ -20,7 +20,7 @@ await client.Job.Open.PostAsync(
 ```
 
 ```python title="Python"
-from space_gass_api.models.open_job_request import OpenJobRequest
+from space_gass_api.models import OpenJobRequest
 
 await client.job.open.post(
     OpenJobRequest(file_path="C:\\Projects\\MyStructure.sg"))
@@ -47,13 +47,9 @@ var status = await client.File.Status.GetAsync(config =>
 ```
 
 ```python title="Python"
-from kiota_abstractions.base_request_configuration import RequestConfiguration
-from space_gass_api.file.status.status_request_builder import StatusRequestBuilder
+status = await client.file.status.get(file_path=r"C:\Projects\MyStructure.sg")
 
-query_params = StatusRequestBuilder.StatusRequestBuilderGetQueryParameters(
-    file_path=r"C:\Projects\MyStructure.sg")
-status = await client.file.status.get(
-    request_configuration=RequestConfiguration(query_parameters=query_params))
+# status contains can_open_safely, description, recommended_action
 ```
 
 ```bash title="curl"
@@ -81,7 +77,7 @@ await client.Job.Save.PostAsync(
 ```
 
 ```python title="Python"
-from space_gass_api.models.save_job_request import SaveJobRequest
+from space_gass_api.models import SaveJobRequest
 
 # Save to current file
 await client.job.save.post(SaveJobRequest())

--- a/sdks/python/client/space_gass_api/__init__.py
+++ b/sdks/python/client/space_gass_api/__init__.py
@@ -7,9 +7,10 @@ client:
 - ``SpaceGassApiClient`` extends the generated ``BaseApiClient``
   with the ``create_client()`` factory method.
 
-- ``.get(**kwargs)`` is auto-enhanced on every builder that has GET
-  query parameters, so callers can pass filters as keyword arguments
-  directly instead of constructing ``RequestConfiguration`` objects.
+- Request methods (``get``/``post``/``patch``/``put``/``delete``) are
+  auto-enhanced on every builder that defines query parameters for that
+  verb, so callers can pass them as keyword arguments directly instead
+  of constructing ``RequestConfiguration`` objects.
 
 Usage:
 
@@ -20,11 +21,13 @@ Usage:
     node = await client.job.structure.nodes.post(models.NodeCreate(x=0, y=0, z=0))
     restrained = await client.job.structure.nodes.get(
         node_type=models.NodeTypeFilter.Restrained)
+    created = await client.job.structure.nodes.bulk.post(
+        bodies, continue_on_error=True)
 """
 
-from .space_gass_api_client import _enhance_get_methods
+from .space_gass_api_client import _enhance_request_methods
 
-_enhance_get_methods()
+_enhance_request_methods()
 
 from .space_gass_api_client import SpaceGassApiClient
 from .upload_requests import ImportTxtRequest, NewFromTemplateRequest

--- a/sdks/python/client/space_gass_api/generated/job/data/data_request_builder.py
+++ b/sdks/python/client/space_gass_api/generated/job/data/data_request_builder.py
@@ -10,7 +10,7 @@ from kiota_abstractions.request_adapter import RequestAdapter
 from kiota_abstractions.request_information import RequestInformation
 from kiota_abstractions.request_option import RequestOption
 from kiota_abstractions.serialization import Parsable, ParsableFactory
-from typing import Any, Optional, TYPE_CHECKING, Union
+from typing import Any, Optional, TYPE_CHECKING, Union, overload
 from warnings import warn
 
 if TYPE_CHECKING:
@@ -30,7 +30,17 @@ class DataRequestBuilder(BaseRequestBuilder):
         """
         super().__init__(request_adapter, "{+baseurl}/job/data{?force*}", path_parameters)
     
-    async def delete(self,request_configuration: Optional[RequestConfiguration[DataRequestBuilderDeleteQueryParameters]] = None) -> Optional[Job]:
+    # --- @overload added by regen_python_inits.py ---
+    @overload
+    async def delete(
+        self,
+        *,
+        force: Optional[bool] = None,
+    ) -> Optional[Job]: ...
+    @overload
+    async def delete(self, request_configuration: Optional[RequestConfiguration[DataRequestBuilderDeleteQueryParameters]] = None) -> Optional[Job]: ...
+    # --- end overloads ---
+    async def delete(self,request_configuration: Optional[RequestConfiguration[DataRequestBuilderDeleteQueryParameters]] = None, **kwargs) -> Optional[Job]:
         """
         Clears all model data while keeping current configuration (units, settings).Deletes ATS data files but preserves the job configuration.Returns the job object with zeroed model summary counts.
         param request_configuration: Configuration for the request such as headers, query parameters, and middleware options.

--- a/sdks/python/client/space_gass_api/generated/job/filters/bulk/bulk_request_builder.py
+++ b/sdks/python/client/space_gass_api/generated/job/filters/bulk/bulk_request_builder.py
@@ -10,7 +10,7 @@ from kiota_abstractions.request_adapter import RequestAdapter
 from kiota_abstractions.request_information import RequestInformation
 from kiota_abstractions.request_option import RequestOption
 from kiota_abstractions.serialization import Parsable, ParsableFactory
-from typing import Any, Optional, TYPE_CHECKING, Union
+from typing import Any, Optional, TYPE_CHECKING, Union, overload
 from warnings import warn
 
 if TYPE_CHECKING:
@@ -33,7 +33,18 @@ class BulkRequestBuilder(BaseRequestBuilder):
         """
         super().__init__(request_adapter, "{+baseurl}/job/filters/bulk{?continueOnError*}", path_parameters)
     
-    async def delete(self,body: list[int], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderDeleteQueryParameters]] = None) -> Optional[BulkDeletedBulkResult]:
+    # --- @overload added by regen_python_inits.py ---
+    @overload
+    async def delete(
+        self,
+        body: list[int],
+        *,
+        continue_on_error: Optional[bool] = None,
+    ) -> Optional[BulkDeletedBulkResult]: ...
+    @overload
+    async def delete(self, body: list[int], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderDeleteQueryParameters]] = None) -> Optional[BulkDeletedBulkResult]: ...
+    # --- end overloads ---
+    async def delete(self,body: list[int], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderDeleteQueryParameters]] = None, **kwargs) -> Optional[BulkDeletedBulkResult]:
         """
         Deletes multiple filters in a single request.
         param body: The request body
@@ -59,7 +70,18 @@ class BulkRequestBuilder(BaseRequestBuilder):
 
         return await self.request_adapter.send_async(request_info, BulkDeletedBulkResult, error_mapping)
     
-    async def patch(self,body: list[FilterUpdate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPatchQueryParameters]] = None) -> Optional[FilterBulkResult]:
+    # --- @overload added by regen_python_inits.py ---
+    @overload
+    async def patch(
+        self,
+        body: list[FilterUpdate],
+        *,
+        continue_on_error: Optional[bool] = None,
+    ) -> Optional[FilterBulkResult]: ...
+    @overload
+    async def patch(self, body: list[FilterUpdate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPatchQueryParameters]] = None) -> Optional[FilterBulkResult]: ...
+    # --- end overloads ---
+    async def patch(self,body: list[FilterUpdate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPatchQueryParameters]] = None, **kwargs) -> Optional[FilterBulkResult]:
         """
         Partially updates multiple filters in a single request.
         param body: The request body
@@ -85,7 +107,18 @@ class BulkRequestBuilder(BaseRequestBuilder):
 
         return await self.request_adapter.send_async(request_info, FilterBulkResult, error_mapping)
     
-    async def post(self,body: list[FilterCreate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPostQueryParameters]] = None) -> Optional[FilterBulkResult]:
+    # --- @overload added by regen_python_inits.py ---
+    @overload
+    async def post(
+        self,
+        body: list[FilterCreate],
+        *,
+        continue_on_error: Optional[bool] = None,
+    ) -> Optional[FilterBulkResult]: ...
+    @overload
+    async def post(self, body: list[FilterCreate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPostQueryParameters]] = None) -> Optional[FilterBulkResult]: ...
+    # --- end overloads ---
+    async def post(self,body: list[FilterCreate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPostQueryParameters]] = None, **kwargs) -> Optional[FilterBulkResult]:
         """
         Creates multiple filters in a single request.
         param body: The request body

--- a/sdks/python/client/space_gass_api/generated/job/loads/combination_load_cases/bulk/bulk_request_builder.py
+++ b/sdks/python/client/space_gass_api/generated/job/loads/combination_load_cases/bulk/bulk_request_builder.py
@@ -10,7 +10,7 @@ from kiota_abstractions.request_adapter import RequestAdapter
 from kiota_abstractions.request_information import RequestInformation
 from kiota_abstractions.request_option import RequestOption
 from kiota_abstractions.serialization import Parsable, ParsableFactory
-from typing import Any, Optional, TYPE_CHECKING, Union
+from typing import Any, Optional, TYPE_CHECKING, Union, overload
 from warnings import warn
 
 if TYPE_CHECKING:
@@ -33,7 +33,18 @@ class BulkRequestBuilder(BaseRequestBuilder):
         """
         super().__init__(request_adapter, "{+baseurl}/job/loads/combination-load-cases/bulk{?continueOnError*}", path_parameters)
     
-    async def delete(self,body: list[int], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderDeleteQueryParameters]] = None) -> Optional[BulkDeletedBulkResult]:
+    # --- @overload added by regen_python_inits.py ---
+    @overload
+    async def delete(
+        self,
+        body: list[int],
+        *,
+        continue_on_error: Optional[bool] = None,
+    ) -> Optional[BulkDeletedBulkResult]: ...
+    @overload
+    async def delete(self, body: list[int], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderDeleteQueryParameters]] = None) -> Optional[BulkDeletedBulkResult]: ...
+    # --- end overloads ---
+    async def delete(self,body: list[int], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderDeleteQueryParameters]] = None, **kwargs) -> Optional[BulkDeletedBulkResult]:
         """
         Deletes multiple combination load cases by Id. The body is a JSON array of integer Ids(e.g. `[10, 11, 12]`). Each deletion removes the case and its items atomically.
         param body: The request body
@@ -59,7 +70,18 @@ class BulkRequestBuilder(BaseRequestBuilder):
 
         return await self.request_adapter.send_async(request_info, BulkDeletedBulkResult, error_mapping)
     
-    async def patch(self,body: list[CombinationLoadCaseUpdate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPatchQueryParameters]] = None) -> Optional[LoadCaseBulkResult]:
+    # --- @overload added by regen_python_inits.py ---
+    @overload
+    async def patch(
+        self,
+        body: list[CombinationLoadCaseUpdate],
+        *,
+        continue_on_error: Optional[bool] = None,
+    ) -> Optional[LoadCaseBulkResult]: ...
+    @overload
+    async def patch(self, body: list[CombinationLoadCaseUpdate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPatchQueryParameters]] = None) -> Optional[LoadCaseBulkResult]: ...
+    # --- end overloads ---
+    async def patch(self,body: list[CombinationLoadCaseUpdate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPatchQueryParameters]] = None, **kwargs) -> Optional[LoadCaseBulkResult]:
         """
         Partially updates multiple combination load cases. Each item must include its `id`.As with the single-item PATCH, an optional `combinationItems` list on a rowperforms a full-replace of that case's items. Validation runs upfront on the wholerequest; with `continueOnError=true`, valid rows are applied and failures are reported per-item.
         param body: The request body
@@ -85,7 +107,18 @@ class BulkRequestBuilder(BaseRequestBuilder):
 
         return await self.request_adapter.send_async(request_info, LoadCaseBulkResult, error_mapping)
     
-    async def post(self,body: list[CombinationLoadCaseCreate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPostQueryParameters]] = None) -> Optional[LoadCaseBulkResult]:
+    # --- @overload added by regen_python_inits.py ---
+    @overload
+    async def post(
+        self,
+        body: list[CombinationLoadCaseCreate],
+        *,
+        continue_on_error: Optional[bool] = None,
+    ) -> Optional[LoadCaseBulkResult]: ...
+    @overload
+    async def post(self, body: list[CombinationLoadCaseCreate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPostQueryParameters]] = None) -> Optional[LoadCaseBulkResult]: ...
+    # --- end overloads ---
+    async def post(self,body: list[CombinationLoadCaseCreate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPostQueryParameters]] = None, **kwargs) -> Optional[LoadCaseBulkResult]:
         """
         Creates multiple combination load cases in a single request. Each item is a fullcase + items payload; validation runs upfront on the whole request. With`continueOnError=false` (default) any failure rejects the whole request; with`continueOnError=true`, valid items are created and failures are reported per-item.Each created case is atomic individually (case + items, with rollback on failure).
         param body: The request body

--- a/sdks/python/client/space_gass_api/generated/job/loads/load_case_groups/bulk/bulk_request_builder.py
+++ b/sdks/python/client/space_gass_api/generated/job/loads/load_case_groups/bulk/bulk_request_builder.py
@@ -10,7 +10,7 @@ from kiota_abstractions.request_adapter import RequestAdapter
 from kiota_abstractions.request_information import RequestInformation
 from kiota_abstractions.request_option import RequestOption
 from kiota_abstractions.serialization import Parsable, ParsableFactory
-from typing import Any, Optional, TYPE_CHECKING, Union
+from typing import Any, Optional, TYPE_CHECKING, Union, overload
 from warnings import warn
 
 if TYPE_CHECKING:
@@ -33,7 +33,18 @@ class BulkRequestBuilder(BaseRequestBuilder):
         """
         super().__init__(request_adapter, "{+baseurl}/job/loads/load-case-groups/bulk{?continueOnError*}", path_parameters)
     
-    async def delete(self,body: list[int], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderDeleteQueryParameters]] = None) -> Optional[BulkDeletedBulkResult]:
+    # --- @overload added by regen_python_inits.py ---
+    @overload
+    async def delete(
+        self,
+        body: list[int],
+        *,
+        continue_on_error: Optional[bool] = None,
+    ) -> Optional[BulkDeletedBulkResult]: ...
+    @overload
+    async def delete(self, body: list[int], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderDeleteQueryParameters]] = None) -> Optional[BulkDeletedBulkResult]: ...
+    # --- end overloads ---
+    async def delete(self,body: list[int], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderDeleteQueryParameters]] = None, **kwargs) -> Optional[BulkDeletedBulkResult]:
         """
         Deletes multiple entities by Id. The body is a JSON array of integer Ids(e.g. `[1, 5, 10]`) — consistent with every other bulk-delete endpointin the API (see CLAUDE.md "Query Parameter Conventions").            For cascading entities (Nodes, Members, Plates), `continueOnError` governs only theper-Id existence pre-check: a missing Id is reported and, when `false`, aborts thebatch. The cascade itself is planned and executed as a single unit — if cleanup failsmid-execution the entire batch is rolled back (affected datasheets are reloaded), so nopartial cascade is persisted.
         param body: The request body
@@ -59,7 +70,18 @@ class BulkRequestBuilder(BaseRequestBuilder):
 
         return await self.request_adapter.send_async(request_info, BulkDeletedBulkResult, error_mapping)
     
-    async def patch(self,body: list[LoadCaseGroupUpdate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPatchQueryParameters]] = None) -> Optional[LoadCaseGroupBulkResult]:
+    # --- @overload added by regen_python_inits.py ---
+    @overload
+    async def patch(
+        self,
+        body: list[LoadCaseGroupUpdate],
+        *,
+        continue_on_error: Optional[bool] = None,
+    ) -> Optional[LoadCaseGroupBulkResult]: ...
+    @overload
+    async def patch(self, body: list[LoadCaseGroupUpdate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPatchQueryParameters]] = None) -> Optional[LoadCaseGroupBulkResult]: ...
+    # --- end overloads ---
+    async def patch(self,body: list[LoadCaseGroupUpdate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPatchQueryParameters]] = None, **kwargs) -> Optional[LoadCaseGroupBulkResult]:
         """
         Updates multiple items in a bulk operation.Each item must include its Id in the request body.If a validator is registered, all items are validated upfront before any are updated.
         param body: The request body
@@ -85,7 +107,18 @@ class BulkRequestBuilder(BaseRequestBuilder):
 
         return await self.request_adapter.send_async(request_info, LoadCaseGroupBulkResult, error_mapping)
     
-    async def post(self,body: list[LoadCaseGroupCreate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPostQueryParameters]] = None) -> Optional[LoadCaseGroupBulkResult]:
+    # --- @overload added by regen_python_inits.py ---
+    @overload
+    async def post(
+        self,
+        body: list[LoadCaseGroupCreate],
+        *,
+        continue_on_error: Optional[bool] = None,
+    ) -> Optional[LoadCaseGroupBulkResult]: ...
+    @overload
+    async def post(self, body: list[LoadCaseGroupCreate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPostQueryParameters]] = None) -> Optional[LoadCaseGroupBulkResult]: ...
+    # --- end overloads ---
+    async def post(self,body: list[LoadCaseGroupCreate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPostQueryParameters]] = None, **kwargs) -> Optional[LoadCaseGroupBulkResult]:
         """
         Creates multiple items in a bulk operation.If a validator is registered, all items are validated upfront before any are created.
         param body: The request body

--- a/sdks/python/client/space_gass_api/generated/job/loads/load_cases/bulk/bulk_request_builder.py
+++ b/sdks/python/client/space_gass_api/generated/job/loads/load_cases/bulk/bulk_request_builder.py
@@ -10,7 +10,7 @@ from kiota_abstractions.request_adapter import RequestAdapter
 from kiota_abstractions.request_information import RequestInformation
 from kiota_abstractions.request_option import RequestOption
 from kiota_abstractions.serialization import Parsable, ParsableFactory
-from typing import Any, Optional, TYPE_CHECKING, Union
+from typing import Any, Optional, TYPE_CHECKING, Union, overload
 from warnings import warn
 
 if TYPE_CHECKING:
@@ -33,7 +33,18 @@ class BulkRequestBuilder(BaseRequestBuilder):
         """
         super().__init__(request_adapter, "{+baseurl}/job/loads/load-cases/bulk{?continueOnError*}", path_parameters)
     
-    async def delete(self,body: list[int], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderDeleteQueryParameters]] = None) -> Optional[BulkDeletedBulkResult]:
+    # --- @overload added by regen_python_inits.py ---
+    @overload
+    async def delete(
+        self,
+        body: list[int],
+        *,
+        continue_on_error: Optional[bool] = None,
+    ) -> Optional[BulkDeletedBulkResult]: ...
+    @overload
+    async def delete(self, body: list[int], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderDeleteQueryParameters]] = None) -> Optional[BulkDeletedBulkResult]: ...
+    # --- end overloads ---
+    async def delete(self,body: list[int], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderDeleteQueryParameters]] = None, **kwargs) -> Optional[BulkDeletedBulkResult]:
         """
         Deletes multiple load cases by Id. The body is a JSON array of integer Ids(e.g. `[1, 5, 10]`). As with `DELETE /{id}`, this removes thetitle/notes/metadata only — assigned loads and combination items are preserved.
         param body: The request body
@@ -59,7 +70,18 @@ class BulkRequestBuilder(BaseRequestBuilder):
 
         return await self.request_adapter.send_async(request_info, BulkDeletedBulkResult, error_mapping)
     
-    async def patch(self,body: list[LoadCaseUpdate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPatchQueryParameters]] = None) -> Optional[LoadCaseBulkResult]:
+    # --- @overload added by regen_python_inits.py ---
+    @overload
+    async def patch(
+        self,
+        body: list[LoadCaseUpdate],
+        *,
+        continue_on_error: Optional[bool] = None,
+    ) -> Optional[LoadCaseBulkResult]: ...
+    @overload
+    async def patch(self, body: list[LoadCaseUpdate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPatchQueryParameters]] = None) -> Optional[LoadCaseBulkResult]: ...
+    # --- end overloads ---
+    async def patch(self,body: list[LoadCaseUpdate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPatchQueryParameters]] = None, **kwargs) -> Optional[LoadCaseBulkResult]:
         """
         Partially updates multiple load cases. Each item must include its `id`.Validation runs upfront; with `continueOnError=false` (default) any failurerejects the whole request. With `continueOnError=true`, valid items are updatedand failures are reported per-item.
         param body: The request body
@@ -85,7 +107,18 @@ class BulkRequestBuilder(BaseRequestBuilder):
 
         return await self.request_adapter.send_async(request_info, LoadCaseBulkResult, error_mapping)
     
-    async def post(self,body: list[LoadCaseCreate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPostQueryParameters]] = None) -> Optional[LoadCaseBulkResult]:
+    # --- @overload added by regen_python_inits.py ---
+    @overload
+    async def post(
+        self,
+        body: list[LoadCaseCreate],
+        *,
+        continue_on_error: Optional[bool] = None,
+    ) -> Optional[LoadCaseBulkResult]: ...
+    @overload
+    async def post(self, body: list[LoadCaseCreate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPostQueryParameters]] = None) -> Optional[LoadCaseBulkResult]: ...
+    # --- end overloads ---
+    async def post(self,body: list[LoadCaseCreate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPostQueryParameters]] = None, **kwargs) -> Optional[LoadCaseBulkResult]:
         """
         Creates multiple load cases in a single request. Validation runs upfront on the wholerequest; if any item fails and `continueOnError` is false (default), the entirerequest is rejected. With `continueOnError=true`, valid items are created andfailures are reported per-item in the response.
         param body: The request body

--- a/sdks/python/client/space_gass_api/generated/job/loads/load_categories/bulk/bulk_request_builder.py
+++ b/sdks/python/client/space_gass_api/generated/job/loads/load_categories/bulk/bulk_request_builder.py
@@ -10,7 +10,7 @@ from kiota_abstractions.request_adapter import RequestAdapter
 from kiota_abstractions.request_information import RequestInformation
 from kiota_abstractions.request_option import RequestOption
 from kiota_abstractions.serialization import Parsable, ParsableFactory
-from typing import Any, Optional, TYPE_CHECKING, Union
+from typing import Any, Optional, TYPE_CHECKING, Union, overload
 from warnings import warn
 
 if TYPE_CHECKING:
@@ -33,7 +33,18 @@ class BulkRequestBuilder(BaseRequestBuilder):
         """
         super().__init__(request_adapter, "{+baseurl}/job/loads/load-categories/bulk{?continueOnError*}", path_parameters)
     
-    async def delete(self,body: list[int], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderDeleteQueryParameters]] = None) -> Optional[BulkDeletedBulkResult]:
+    # --- @overload added by regen_python_inits.py ---
+    @overload
+    async def delete(
+        self,
+        body: list[int],
+        *,
+        continue_on_error: Optional[bool] = None,
+    ) -> Optional[BulkDeletedBulkResult]: ...
+    @overload
+    async def delete(self, body: list[int], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderDeleteQueryParameters]] = None) -> Optional[BulkDeletedBulkResult]: ...
+    # --- end overloads ---
+    async def delete(self,body: list[int], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderDeleteQueryParameters]] = None, **kwargs) -> Optional[BulkDeletedBulkResult]:
         """
         Deletes multiple entities by Id. The body is a JSON array of integer Ids(e.g. `[1, 5, 10]`) — consistent with every other bulk-delete endpointin the API (see CLAUDE.md "Query Parameter Conventions").            For cascading entities (Nodes, Members, Plates), `continueOnError` governs only theper-Id existence pre-check: a missing Id is reported and, when `false`, aborts thebatch. The cascade itself is planned and executed as a single unit — if cleanup failsmid-execution the entire batch is rolled back (affected datasheets are reloaded), so nopartial cascade is persisted.
         param body: The request body
@@ -59,7 +70,18 @@ class BulkRequestBuilder(BaseRequestBuilder):
 
         return await self.request_adapter.send_async(request_info, BulkDeletedBulkResult, error_mapping)
     
-    async def patch(self,body: list[LoadCategoryUpdate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPatchQueryParameters]] = None) -> Optional[LoadCategoryBulkResult]:
+    # --- @overload added by regen_python_inits.py ---
+    @overload
+    async def patch(
+        self,
+        body: list[LoadCategoryUpdate],
+        *,
+        continue_on_error: Optional[bool] = None,
+    ) -> Optional[LoadCategoryBulkResult]: ...
+    @overload
+    async def patch(self, body: list[LoadCategoryUpdate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPatchQueryParameters]] = None) -> Optional[LoadCategoryBulkResult]: ...
+    # --- end overloads ---
+    async def patch(self,body: list[LoadCategoryUpdate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPatchQueryParameters]] = None, **kwargs) -> Optional[LoadCategoryBulkResult]:
         """
         Updates multiple items in a bulk operation.Each item must include its Id in the request body.If a validator is registered, all items are validated upfront before any are updated.
         param body: The request body
@@ -85,7 +107,18 @@ class BulkRequestBuilder(BaseRequestBuilder):
 
         return await self.request_adapter.send_async(request_info, LoadCategoryBulkResult, error_mapping)
     
-    async def post(self,body: list[LoadCategoryCreate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPostQueryParameters]] = None) -> Optional[LoadCategoryBulkResult]:
+    # --- @overload added by regen_python_inits.py ---
+    @overload
+    async def post(
+        self,
+        body: list[LoadCategoryCreate],
+        *,
+        continue_on_error: Optional[bool] = None,
+    ) -> Optional[LoadCategoryBulkResult]: ...
+    @overload
+    async def post(self, body: list[LoadCategoryCreate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPostQueryParameters]] = None) -> Optional[LoadCategoryBulkResult]: ...
+    # --- end overloads ---
+    async def post(self,body: list[LoadCategoryCreate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPostQueryParameters]] = None, **kwargs) -> Optional[LoadCategoryBulkResult]:
         """
         Creates multiple items in a bulk operation.If a validator is registered, all items are validated upfront before any are created.
         param body: The request body

--- a/sdks/python/client/space_gass_api/generated/job/loads/lumped_mass_loads/bulk/bulk_request_builder.py
+++ b/sdks/python/client/space_gass_api/generated/job/loads/lumped_mass_loads/bulk/bulk_request_builder.py
@@ -10,7 +10,7 @@ from kiota_abstractions.request_adapter import RequestAdapter
 from kiota_abstractions.request_information import RequestInformation
 from kiota_abstractions.request_option import RequestOption
 from kiota_abstractions.serialization import Parsable, ParsableFactory
-from typing import Any, Optional, TYPE_CHECKING, Union
+from typing import Any, Optional, TYPE_CHECKING, Union, overload
 from warnings import warn
 
 if TYPE_CHECKING:
@@ -34,7 +34,18 @@ class BulkRequestBuilder(BaseRequestBuilder):
         """
         super().__init__(request_adapter, "{+baseurl}/job/loads/lumped-mass-loads/bulk{?continueOnError*}", path_parameters)
     
-    async def delete(self,body: list[LumpedMassLoadKey], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderDeleteQueryParameters]] = None) -> Optional[LumpedMassLoadKeyBulkResult]:
+    # --- @overload added by regen_python_inits.py ---
+    @overload
+    async def delete(
+        self,
+        body: list[LumpedMassLoadKey],
+        *,
+        continue_on_error: Optional[bool] = None,
+    ) -> Optional[LumpedMassLoadKeyBulkResult]: ...
+    @overload
+    async def delete(self, body: list[LumpedMassLoadKey], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderDeleteQueryParameters]] = None) -> Optional[LumpedMassLoadKeyBulkResult]: ...
+    # --- end overloads ---
+    async def delete(self,body: list[LumpedMassLoadKey], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderDeleteQueryParameters]] = None, **kwargs) -> Optional[LumpedMassLoadKeyBulkResult]:
         """
         Deletes multiple lumped mass loads. Both case and node are required for each entry —providing only a case does not delete all lumped masses for that case.The succeeded array echoes back the Ids of each successfully deleted load.
         param body: The request body
@@ -60,7 +71,18 @@ class BulkRequestBuilder(BaseRequestBuilder):
 
         return await self.request_adapter.send_async(request_info, LumpedMassLoadKeyBulkResult, error_mapping)
     
-    async def patch(self,body: list[LumpedMassLoadUpdate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPatchQueryParameters]] = None) -> Optional[LumpedMassLoadBulkResult]:
+    # --- @overload added by regen_python_inits.py ---
+    @overload
+    async def patch(
+        self,
+        body: list[LumpedMassLoadUpdate],
+        *,
+        continue_on_error: Optional[bool] = None,
+    ) -> Optional[LumpedMassLoadBulkResult]: ...
+    @overload
+    async def patch(self, body: list[LumpedMassLoadUpdate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPatchQueryParameters]] = None) -> Optional[LumpedMassLoadBulkResult]: ...
+    # --- end overloads ---
+    async def patch(self,body: list[LumpedMassLoadUpdate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPatchQueryParameters]] = None, **kwargs) -> Optional[LumpedMassLoadBulkResult]:
         """
         Updates multiple lumped mass loads. Each item must include case and node in the body.All load cases referenced must be Primary.
         param body: The request body
@@ -86,7 +108,18 @@ class BulkRequestBuilder(BaseRequestBuilder):
 
         return await self.request_adapter.send_async(request_info, LumpedMassLoadBulkResult, error_mapping)
     
-    async def post(self,body: list[LumpedMassLoadCreate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPostQueryParameters]] = None) -> Optional[LumpedMassLoadBulkResult]:
+    # --- @overload added by regen_python_inits.py ---
+    @overload
+    async def post(
+        self,
+        body: list[LumpedMassLoadCreate],
+        *,
+        continue_on_error: Optional[bool] = None,
+    ) -> Optional[LumpedMassLoadBulkResult]: ...
+    @overload
+    async def post(self, body: list[LumpedMassLoadCreate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPostQueryParameters]] = None) -> Optional[LumpedMassLoadBulkResult]: ...
+    # --- end overloads ---
+    async def post(self,body: list[LumpedMassLoadCreate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPostQueryParameters]] = None, **kwargs) -> Optional[LumpedMassLoadBulkResult]:
         """
         Creates multiple loads in a bulk operation.All load cases referenced must exist and be Primary load cases.
         param body: The request body

--- a/sdks/python/client/space_gass_api/generated/job/loads/member_concentrated_loads/bulk/bulk_request_builder.py
+++ b/sdks/python/client/space_gass_api/generated/job/loads/member_concentrated_loads/bulk/bulk_request_builder.py
@@ -10,7 +10,7 @@ from kiota_abstractions.request_adapter import RequestAdapter
 from kiota_abstractions.request_information import RequestInformation
 from kiota_abstractions.request_option import RequestOption
 from kiota_abstractions.serialization import Parsable, ParsableFactory
-from typing import Any, Optional, TYPE_CHECKING, Union
+from typing import Any, Optional, TYPE_CHECKING, Union, overload
 from warnings import warn
 
 if TYPE_CHECKING:
@@ -34,7 +34,18 @@ class BulkRequestBuilder(BaseRequestBuilder):
         """
         super().__init__(request_adapter, "{+baseurl}/job/loads/member-concentrated-loads/bulk{?continueOnError*}", path_parameters)
     
-    async def delete(self,body: list[MemberConcentratedLoadKey], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderDeleteQueryParameters]] = None) -> Optional[MemberConcentratedLoadKeyBulkResult]:
+    # --- @overload added by regen_python_inits.py ---
+    @overload
+    async def delete(
+        self,
+        body: list[MemberConcentratedLoadKey],
+        *,
+        continue_on_error: Optional[bool] = None,
+    ) -> Optional[MemberConcentratedLoadKeyBulkResult]: ...
+    @overload
+    async def delete(self, body: list[MemberConcentratedLoadKey], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderDeleteQueryParameters]] = None) -> Optional[MemberConcentratedLoadKeyBulkResult]: ...
+    # --- end overloads ---
+    async def delete(self,body: list[MemberConcentratedLoadKey], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderDeleteQueryParameters]] = None, **kwargs) -> Optional[MemberConcentratedLoadKeyBulkResult]:
         """
         Deletes multiple member concentrated loads. Case, member, and subLoad are all required for each entry.The succeeded array echoes back the Ids of each successfully deleted load.
         param body: The request body
@@ -60,7 +71,18 @@ class BulkRequestBuilder(BaseRequestBuilder):
 
         return await self.request_adapter.send_async(request_info, MemberConcentratedLoadKeyBulkResult, error_mapping)
     
-    async def patch(self,body: list[MemberConcentratedLoadUpdate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPatchQueryParameters]] = None) -> Optional[MemberConcentratedLoadBulkResult]:
+    # --- @overload added by regen_python_inits.py ---
+    @overload
+    async def patch(
+        self,
+        body: list[MemberConcentratedLoadUpdate],
+        *,
+        continue_on_error: Optional[bool] = None,
+    ) -> Optional[MemberConcentratedLoadBulkResult]: ...
+    @overload
+    async def patch(self, body: list[MemberConcentratedLoadUpdate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPatchQueryParameters]] = None) -> Optional[MemberConcentratedLoadBulkResult]: ...
+    # --- end overloads ---
+    async def patch(self,body: list[MemberConcentratedLoadUpdate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPatchQueryParameters]] = None, **kwargs) -> Optional[MemberConcentratedLoadBulkResult]:
         """
         Updates multiple member concentrated loads. Each item must include case, member, and subLoad in the body.All load cases referenced must be Primary.
         param body: The request body
@@ -86,7 +108,18 @@ class BulkRequestBuilder(BaseRequestBuilder):
 
         return await self.request_adapter.send_async(request_info, MemberConcentratedLoadBulkResult, error_mapping)
     
-    async def post(self,body: list[MemberConcentratedLoadCreate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPostQueryParameters]] = None) -> Optional[MemberConcentratedLoadBulkResult]:
+    # --- @overload added by regen_python_inits.py ---
+    @overload
+    async def post(
+        self,
+        body: list[MemberConcentratedLoadCreate],
+        *,
+        continue_on_error: Optional[bool] = None,
+    ) -> Optional[MemberConcentratedLoadBulkResult]: ...
+    @overload
+    async def post(self, body: list[MemberConcentratedLoadCreate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPostQueryParameters]] = None) -> Optional[MemberConcentratedLoadBulkResult]: ...
+    # --- end overloads ---
+    async def post(self,body: list[MemberConcentratedLoadCreate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPostQueryParameters]] = None, **kwargs) -> Optional[MemberConcentratedLoadBulkResult]:
         """
         Creates multiple loads in a bulk operation.All load cases referenced must exist and be Primary load cases.
         param body: The request body

--- a/sdks/python/client/space_gass_api/generated/job/loads/member_distributed_loads/bulk/bulk_request_builder.py
+++ b/sdks/python/client/space_gass_api/generated/job/loads/member_distributed_loads/bulk/bulk_request_builder.py
@@ -10,7 +10,7 @@ from kiota_abstractions.request_adapter import RequestAdapter
 from kiota_abstractions.request_information import RequestInformation
 from kiota_abstractions.request_option import RequestOption
 from kiota_abstractions.serialization import Parsable, ParsableFactory
-from typing import Any, Optional, TYPE_CHECKING, Union
+from typing import Any, Optional, TYPE_CHECKING, Union, overload
 from warnings import warn
 
 if TYPE_CHECKING:
@@ -34,7 +34,18 @@ class BulkRequestBuilder(BaseRequestBuilder):
         """
         super().__init__(request_adapter, "{+baseurl}/job/loads/member-distributed-loads/bulk{?continueOnError*}", path_parameters)
     
-    async def delete(self,body: list[MemberDistributedLoadKey], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderDeleteQueryParameters]] = None) -> Optional[MemberDistributedLoadKeyBulkResult]:
+    # --- @overload added by regen_python_inits.py ---
+    @overload
+    async def delete(
+        self,
+        body: list[MemberDistributedLoadKey],
+        *,
+        continue_on_error: Optional[bool] = None,
+    ) -> Optional[MemberDistributedLoadKeyBulkResult]: ...
+    @overload
+    async def delete(self, body: list[MemberDistributedLoadKey], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderDeleteQueryParameters]] = None) -> Optional[MemberDistributedLoadKeyBulkResult]: ...
+    # --- end overloads ---
+    async def delete(self,body: list[MemberDistributedLoadKey], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderDeleteQueryParameters]] = None, **kwargs) -> Optional[MemberDistributedLoadKeyBulkResult]:
         """
         Deletes multiple member distributed loads. Case, member, and subLoad are all required for each entry.The succeeded array echoes back the Ids of each successfully deleted load.
         param body: The request body
@@ -60,7 +71,18 @@ class BulkRequestBuilder(BaseRequestBuilder):
 
         return await self.request_adapter.send_async(request_info, MemberDistributedLoadKeyBulkResult, error_mapping)
     
-    async def patch(self,body: list[MemberDistributedLoadUpdate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPatchQueryParameters]] = None) -> Optional[MemberDistributedLoadBulkResult]:
+    # --- @overload added by regen_python_inits.py ---
+    @overload
+    async def patch(
+        self,
+        body: list[MemberDistributedLoadUpdate],
+        *,
+        continue_on_error: Optional[bool] = None,
+    ) -> Optional[MemberDistributedLoadBulkResult]: ...
+    @overload
+    async def patch(self, body: list[MemberDistributedLoadUpdate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPatchQueryParameters]] = None) -> Optional[MemberDistributedLoadBulkResult]: ...
+    # --- end overloads ---
+    async def patch(self,body: list[MemberDistributedLoadUpdate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPatchQueryParameters]] = None, **kwargs) -> Optional[MemberDistributedLoadBulkResult]:
         """
         Updates multiple member distributed loads. Each item must include case, member, and subLoad in the body.All load cases referenced must be Primary.
         param body: The request body
@@ -86,7 +108,18 @@ class BulkRequestBuilder(BaseRequestBuilder):
 
         return await self.request_adapter.send_async(request_info, MemberDistributedLoadBulkResult, error_mapping)
     
-    async def post(self,body: list[MemberDistributedLoadCreate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPostQueryParameters]] = None) -> Optional[MemberDistributedLoadBulkResult]:
+    # --- @overload added by regen_python_inits.py ---
+    @overload
+    async def post(
+        self,
+        body: list[MemberDistributedLoadCreate],
+        *,
+        continue_on_error: Optional[bool] = None,
+    ) -> Optional[MemberDistributedLoadBulkResult]: ...
+    @overload
+    async def post(self, body: list[MemberDistributedLoadCreate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPostQueryParameters]] = None) -> Optional[MemberDistributedLoadBulkResult]: ...
+    # --- end overloads ---
+    async def post(self,body: list[MemberDistributedLoadCreate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPostQueryParameters]] = None, **kwargs) -> Optional[MemberDistributedLoadBulkResult]:
         """
         Creates multiple loads in a bulk operation.All load cases referenced must exist and be Primary load cases.
         param body: The request body

--- a/sdks/python/client/space_gass_api/generated/job/loads/member_distributed_moments/bulk/bulk_request_builder.py
+++ b/sdks/python/client/space_gass_api/generated/job/loads/member_distributed_moments/bulk/bulk_request_builder.py
@@ -10,7 +10,7 @@ from kiota_abstractions.request_adapter import RequestAdapter
 from kiota_abstractions.request_information import RequestInformation
 from kiota_abstractions.request_option import RequestOption
 from kiota_abstractions.serialization import Parsable, ParsableFactory
-from typing import Any, Optional, TYPE_CHECKING, Union
+from typing import Any, Optional, TYPE_CHECKING, Union, overload
 from warnings import warn
 
 if TYPE_CHECKING:
@@ -34,7 +34,18 @@ class BulkRequestBuilder(BaseRequestBuilder):
         """
         super().__init__(request_adapter, "{+baseurl}/job/loads/member-distributed-moments/bulk{?continueOnError*}", path_parameters)
     
-    async def delete(self,body: list[MemberDistributedMomentKey], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderDeleteQueryParameters]] = None) -> Optional[MemberDistributedMomentKeyBulkResult]:
+    # --- @overload added by regen_python_inits.py ---
+    @overload
+    async def delete(
+        self,
+        body: list[MemberDistributedMomentKey],
+        *,
+        continue_on_error: Optional[bool] = None,
+    ) -> Optional[MemberDistributedMomentKeyBulkResult]: ...
+    @overload
+    async def delete(self, body: list[MemberDistributedMomentKey], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderDeleteQueryParameters]] = None) -> Optional[MemberDistributedMomentKeyBulkResult]: ...
+    # --- end overloads ---
+    async def delete(self,body: list[MemberDistributedMomentKey], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderDeleteQueryParameters]] = None, **kwargs) -> Optional[MemberDistributedMomentKeyBulkResult]:
         """
         Deletes multiple member distributed moments. Case, member, and subLoad are all required for each entry.The succeeded array echoes back the Ids of each successfully deleted load.
         param body: The request body
@@ -60,7 +71,18 @@ class BulkRequestBuilder(BaseRequestBuilder):
 
         return await self.request_adapter.send_async(request_info, MemberDistributedMomentKeyBulkResult, error_mapping)
     
-    async def patch(self,body: list[MemberDistributedMomentUpdate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPatchQueryParameters]] = None) -> Optional[MemberDistributedMomentBulkResult]:
+    # --- @overload added by regen_python_inits.py ---
+    @overload
+    async def patch(
+        self,
+        body: list[MemberDistributedMomentUpdate],
+        *,
+        continue_on_error: Optional[bool] = None,
+    ) -> Optional[MemberDistributedMomentBulkResult]: ...
+    @overload
+    async def patch(self, body: list[MemberDistributedMomentUpdate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPatchQueryParameters]] = None) -> Optional[MemberDistributedMomentBulkResult]: ...
+    # --- end overloads ---
+    async def patch(self,body: list[MemberDistributedMomentUpdate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPatchQueryParameters]] = None, **kwargs) -> Optional[MemberDistributedMomentBulkResult]:
         """
         Updates multiple member distributed moments. Each item must include case, member, and subLoad in the body.All load cases referenced must be Primary.
         param body: The request body
@@ -86,7 +108,18 @@ class BulkRequestBuilder(BaseRequestBuilder):
 
         return await self.request_adapter.send_async(request_info, MemberDistributedMomentBulkResult, error_mapping)
     
-    async def post(self,body: list[MemberDistributedMomentCreate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPostQueryParameters]] = None) -> Optional[MemberDistributedMomentBulkResult]:
+    # --- @overload added by regen_python_inits.py ---
+    @overload
+    async def post(
+        self,
+        body: list[MemberDistributedMomentCreate],
+        *,
+        continue_on_error: Optional[bool] = None,
+    ) -> Optional[MemberDistributedMomentBulkResult]: ...
+    @overload
+    async def post(self, body: list[MemberDistributedMomentCreate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPostQueryParameters]] = None) -> Optional[MemberDistributedMomentBulkResult]: ...
+    # --- end overloads ---
+    async def post(self,body: list[MemberDistributedMomentCreate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPostQueryParameters]] = None, **kwargs) -> Optional[MemberDistributedMomentBulkResult]:
         """
         Creates multiple loads in a bulk operation.All load cases referenced must exist and be Primary load cases.
         param body: The request body

--- a/sdks/python/client/space_gass_api/generated/job/loads/member_prestress_loads/bulk/bulk_request_builder.py
+++ b/sdks/python/client/space_gass_api/generated/job/loads/member_prestress_loads/bulk/bulk_request_builder.py
@@ -10,7 +10,7 @@ from kiota_abstractions.request_adapter import RequestAdapter
 from kiota_abstractions.request_information import RequestInformation
 from kiota_abstractions.request_option import RequestOption
 from kiota_abstractions.serialization import Parsable, ParsableFactory
-from typing import Any, Optional, TYPE_CHECKING, Union
+from typing import Any, Optional, TYPE_CHECKING, Union, overload
 from warnings import warn
 
 if TYPE_CHECKING:
@@ -34,7 +34,18 @@ class BulkRequestBuilder(BaseRequestBuilder):
         """
         super().__init__(request_adapter, "{+baseurl}/job/loads/member-prestress-loads/bulk{?continueOnError*}", path_parameters)
     
-    async def delete(self,body: list[MemberPrestressLoadKey], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderDeleteQueryParameters]] = None) -> Optional[MemberPrestressLoadKeyBulkResult]:
+    # --- @overload added by regen_python_inits.py ---
+    @overload
+    async def delete(
+        self,
+        body: list[MemberPrestressLoadKey],
+        *,
+        continue_on_error: Optional[bool] = None,
+    ) -> Optional[MemberPrestressLoadKeyBulkResult]: ...
+    @overload
+    async def delete(self, body: list[MemberPrestressLoadKey], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderDeleteQueryParameters]] = None) -> Optional[MemberPrestressLoadKeyBulkResult]: ...
+    # --- end overloads ---
+    async def delete(self,body: list[MemberPrestressLoadKey], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderDeleteQueryParameters]] = None, **kwargs) -> Optional[MemberPrestressLoadKeyBulkResult]:
         """
         Deletes multiple member prestress loads. Both case and member are required for each entry —providing only a case does not delete all prestress loads for that case.The succeeded array echoes back the Ids of each successfully deleted load.
         param body: The request body
@@ -60,7 +71,18 @@ class BulkRequestBuilder(BaseRequestBuilder):
 
         return await self.request_adapter.send_async(request_info, MemberPrestressLoadKeyBulkResult, error_mapping)
     
-    async def patch(self,body: list[MemberPrestressLoadUpdate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPatchQueryParameters]] = None) -> Optional[MemberPrestressLoadBulkResult]:
+    # --- @overload added by regen_python_inits.py ---
+    @overload
+    async def patch(
+        self,
+        body: list[MemberPrestressLoadUpdate],
+        *,
+        continue_on_error: Optional[bool] = None,
+    ) -> Optional[MemberPrestressLoadBulkResult]: ...
+    @overload
+    async def patch(self, body: list[MemberPrestressLoadUpdate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPatchQueryParameters]] = None) -> Optional[MemberPrestressLoadBulkResult]: ...
+    # --- end overloads ---
+    async def patch(self,body: list[MemberPrestressLoadUpdate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPatchQueryParameters]] = None, **kwargs) -> Optional[MemberPrestressLoadBulkResult]:
         """
         Updates multiple member prestress loads. Each item must include case and member in the body.All load cases referenced must be Primary.
         param body: The request body
@@ -86,7 +108,18 @@ class BulkRequestBuilder(BaseRequestBuilder):
 
         return await self.request_adapter.send_async(request_info, MemberPrestressLoadBulkResult, error_mapping)
     
-    async def post(self,body: list[MemberPrestressLoadCreate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPostQueryParameters]] = None) -> Optional[MemberPrestressLoadBulkResult]:
+    # --- @overload added by regen_python_inits.py ---
+    @overload
+    async def post(
+        self,
+        body: list[MemberPrestressLoadCreate],
+        *,
+        continue_on_error: Optional[bool] = None,
+    ) -> Optional[MemberPrestressLoadBulkResult]: ...
+    @overload
+    async def post(self, body: list[MemberPrestressLoadCreate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPostQueryParameters]] = None) -> Optional[MemberPrestressLoadBulkResult]: ...
+    # --- end overloads ---
+    async def post(self,body: list[MemberPrestressLoadCreate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPostQueryParameters]] = None, **kwargs) -> Optional[MemberPrestressLoadBulkResult]:
         """
         Creates multiple loads in a bulk operation.All load cases referenced must exist and be Primary load cases.
         param body: The request body

--- a/sdks/python/client/space_gass_api/generated/job/loads/moving_loads/pressures/bulk/bulk_request_builder.py
+++ b/sdks/python/client/space_gass_api/generated/job/loads/moving_loads/pressures/bulk/bulk_request_builder.py
@@ -10,7 +10,7 @@ from kiota_abstractions.request_adapter import RequestAdapter
 from kiota_abstractions.request_information import RequestInformation
 from kiota_abstractions.request_option import RequestOption
 from kiota_abstractions.serialization import Parsable, ParsableFactory
-from typing import Any, Optional, TYPE_CHECKING, Union
+from typing import Any, Optional, TYPE_CHECKING, Union, overload
 from warnings import warn
 
 if TYPE_CHECKING:
@@ -33,7 +33,18 @@ class BulkRequestBuilder(BaseRequestBuilder):
         """
         super().__init__(request_adapter, "{+baseurl}/job/loads/moving-loads/pressures/bulk{?continueOnError*}", path_parameters)
     
-    async def delete(self,body: list[int], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderDeleteQueryParameters]] = None) -> Optional[BulkDeletedBulkResult]:
+    # --- @overload added by regen_python_inits.py ---
+    @overload
+    async def delete(
+        self,
+        body: list[int],
+        *,
+        continue_on_error: Optional[bool] = None,
+    ) -> Optional[BulkDeletedBulkResult]: ...
+    @overload
+    async def delete(self, body: list[int], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderDeleteQueryParameters]] = None) -> Optional[BulkDeletedBulkResult]: ...
+    # --- end overloads ---
+    async def delete(self,body: list[int], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderDeleteQueryParameters]] = None, **kwargs) -> Optional[BulkDeletedBulkResult]:
         """
         Deletes multiple catalog items by Id. The body is a JSON array of integer Ids(e.g. `[1, 5, 10]`). An item referenced by a scenario load fails with an in-use errorrather than being deleted.
         param body: The request body
@@ -59,7 +70,18 @@ class BulkRequestBuilder(BaseRequestBuilder):
 
         return await self.request_adapter.send_async(request_info, BulkDeletedBulkResult, error_mapping)
     
-    async def patch(self,body: list[MovingLoadPressureUpdate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPatchQueryParameters]] = None) -> Optional[MovingLoadPressureBulkResult]:
+    # --- @overload added by regen_python_inits.py ---
+    @overload
+    async def patch(
+        self,
+        body: list[MovingLoadPressureUpdate],
+        *,
+        continue_on_error: Optional[bool] = None,
+    ) -> Optional[MovingLoadPressureBulkResult]: ...
+    @overload
+    async def patch(self, body: list[MovingLoadPressureUpdate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPatchQueryParameters]] = None) -> Optional[MovingLoadPressureBulkResult]: ...
+    # --- end overloads ---
+    async def patch(self,body: list[MovingLoadPressureUpdate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPatchQueryParameters]] = None, **kwargs) -> Optional[MovingLoadPressureBulkResult]:
         """
         Partially updates multiple catalog items in one call; each body item carries the `id`of the item to update. They persist with a single save.
         param body: The request body
@@ -85,7 +107,18 @@ class BulkRequestBuilder(BaseRequestBuilder):
 
         return await self.request_adapter.send_async(request_info, MovingLoadPressureBulkResult, error_mapping)
     
-    async def post(self,body: list[MovingLoadPressureCreate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPostQueryParameters]] = None) -> Optional[MovingLoadPressureBulkResult]:
+    # --- @overload added by regen_python_inits.py ---
+    @overload
+    async def post(
+        self,
+        body: list[MovingLoadPressureCreate],
+        *,
+        continue_on_error: Optional[bool] = None,
+    ) -> Optional[MovingLoadPressureBulkResult]: ...
+    @overload
+    async def post(self, body: list[MovingLoadPressureCreate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPostQueryParameters]] = None) -> Optional[MovingLoadPressureBulkResult]: ...
+    # --- end overloads ---
+    async def post(self,body: list[MovingLoadPressureCreate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPostQueryParameters]] = None, **kwargs) -> Optional[MovingLoadPressureBulkResult]:
         """
         Creates multiple catalog items in one call; they persist with a single save.
         param body: The request body

--- a/sdks/python/client/space_gass_api/generated/job/loads/moving_loads/scenarios/bulk/bulk_request_builder.py
+++ b/sdks/python/client/space_gass_api/generated/job/loads/moving_loads/scenarios/bulk/bulk_request_builder.py
@@ -10,7 +10,7 @@ from kiota_abstractions.request_adapter import RequestAdapter
 from kiota_abstractions.request_information import RequestInformation
 from kiota_abstractions.request_option import RequestOption
 from kiota_abstractions.serialization import Parsable, ParsableFactory
-from typing import Any, Optional, TYPE_CHECKING, Union
+from typing import Any, Optional, TYPE_CHECKING, Union, overload
 from warnings import warn
 
 if TYPE_CHECKING:
@@ -33,7 +33,18 @@ class BulkRequestBuilder(BaseRequestBuilder):
         """
         super().__init__(request_adapter, "{+baseurl}/job/loads/moving-loads/scenarios/bulk{?continueOnError*}", path_parameters)
     
-    async def delete(self,body: list[int], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderDeleteQueryParameters]] = None) -> Optional[BulkDeletedBulkResult]:
+    # --- @overload added by regen_python_inits.py ---
+    @overload
+    async def delete(
+        self,
+        body: list[int],
+        *,
+        continue_on_error: Optional[bool] = None,
+    ) -> Optional[BulkDeletedBulkResult]: ...
+    @overload
+    async def delete(self, body: list[int], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderDeleteQueryParameters]] = None) -> Optional[BulkDeletedBulkResult]: ...
+    # --- end overloads ---
+    async def delete(self,body: list[int], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderDeleteQueryParameters]] = None, **kwargs) -> Optional[BulkDeletedBulkResult]:
         """
         Deletes multiple catalog items by Id. The body is a JSON array of integer Ids(e.g. `[1, 5, 10]`). An item referenced by a scenario load fails with an in-use errorrather than being deleted.
         param body: The request body
@@ -59,7 +70,18 @@ class BulkRequestBuilder(BaseRequestBuilder):
 
         return await self.request_adapter.send_async(request_info, BulkDeletedBulkResult, error_mapping)
     
-    async def patch(self,body: list[MovingLoadScenarioUpdate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPatchQueryParameters]] = None) -> Optional[MovingLoadScenarioBulkResult]:
+    # --- @overload added by regen_python_inits.py ---
+    @overload
+    async def patch(
+        self,
+        body: list[MovingLoadScenarioUpdate],
+        *,
+        continue_on_error: Optional[bool] = None,
+    ) -> Optional[MovingLoadScenarioBulkResult]: ...
+    @overload
+    async def patch(self, body: list[MovingLoadScenarioUpdate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPatchQueryParameters]] = None) -> Optional[MovingLoadScenarioBulkResult]: ...
+    # --- end overloads ---
+    async def patch(self,body: list[MovingLoadScenarioUpdate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPatchQueryParameters]] = None, **kwargs) -> Optional[MovingLoadScenarioBulkResult]:
         """
         Partially updates multiple catalog items in one call; each body item carries the `id`of the item to update. They persist with a single save.
         param body: The request body
@@ -85,7 +107,18 @@ class BulkRequestBuilder(BaseRequestBuilder):
 
         return await self.request_adapter.send_async(request_info, MovingLoadScenarioBulkResult, error_mapping)
     
-    async def post(self,body: list[MovingLoadScenarioCreate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPostQueryParameters]] = None) -> Optional[MovingLoadScenarioBulkResult]:
+    # --- @overload added by regen_python_inits.py ---
+    @overload
+    async def post(
+        self,
+        body: list[MovingLoadScenarioCreate],
+        *,
+        continue_on_error: Optional[bool] = None,
+    ) -> Optional[MovingLoadScenarioBulkResult]: ...
+    @overload
+    async def post(self, body: list[MovingLoadScenarioCreate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPostQueryParameters]] = None) -> Optional[MovingLoadScenarioBulkResult]: ...
+    # --- end overloads ---
+    async def post(self,body: list[MovingLoadScenarioCreate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPostQueryParameters]] = None, **kwargs) -> Optional[MovingLoadScenarioBulkResult]:
         """
         Creates multiple catalog items in one call; they persist with a single save.
         param body: The request body

--- a/sdks/python/client/space_gass_api/generated/job/loads/moving_loads/travel_paths/bulk/bulk_request_builder.py
+++ b/sdks/python/client/space_gass_api/generated/job/loads/moving_loads/travel_paths/bulk/bulk_request_builder.py
@@ -10,7 +10,7 @@ from kiota_abstractions.request_adapter import RequestAdapter
 from kiota_abstractions.request_information import RequestInformation
 from kiota_abstractions.request_option import RequestOption
 from kiota_abstractions.serialization import Parsable, ParsableFactory
-from typing import Any, Optional, TYPE_CHECKING, Union
+from typing import Any, Optional, TYPE_CHECKING, Union, overload
 from warnings import warn
 
 if TYPE_CHECKING:
@@ -33,7 +33,18 @@ class BulkRequestBuilder(BaseRequestBuilder):
         """
         super().__init__(request_adapter, "{+baseurl}/job/loads/moving-loads/travel-paths/bulk{?continueOnError*}", path_parameters)
     
-    async def delete(self,body: list[int], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderDeleteQueryParameters]] = None) -> Optional[BulkDeletedBulkResult]:
+    # --- @overload added by regen_python_inits.py ---
+    @overload
+    async def delete(
+        self,
+        body: list[int],
+        *,
+        continue_on_error: Optional[bool] = None,
+    ) -> Optional[BulkDeletedBulkResult]: ...
+    @overload
+    async def delete(self, body: list[int], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderDeleteQueryParameters]] = None) -> Optional[BulkDeletedBulkResult]: ...
+    # --- end overloads ---
+    async def delete(self,body: list[int], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderDeleteQueryParameters]] = None, **kwargs) -> Optional[BulkDeletedBulkResult]:
         """
         Deletes multiple catalog items by Id. The body is a JSON array of integer Ids(e.g. `[1, 5, 10]`). An item referenced by a scenario load fails with an in-use errorrather than being deleted.
         param body: The request body
@@ -59,7 +70,18 @@ class BulkRequestBuilder(BaseRequestBuilder):
 
         return await self.request_adapter.send_async(request_info, BulkDeletedBulkResult, error_mapping)
     
-    async def patch(self,body: list[MovingLoadTravelPathUpdate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPatchQueryParameters]] = None) -> Optional[MovingLoadTravelPathBulkResult]:
+    # --- @overload added by regen_python_inits.py ---
+    @overload
+    async def patch(
+        self,
+        body: list[MovingLoadTravelPathUpdate],
+        *,
+        continue_on_error: Optional[bool] = None,
+    ) -> Optional[MovingLoadTravelPathBulkResult]: ...
+    @overload
+    async def patch(self, body: list[MovingLoadTravelPathUpdate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPatchQueryParameters]] = None) -> Optional[MovingLoadTravelPathBulkResult]: ...
+    # --- end overloads ---
+    async def patch(self,body: list[MovingLoadTravelPathUpdate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPatchQueryParameters]] = None, **kwargs) -> Optional[MovingLoadTravelPathBulkResult]:
         """
         Partially updates multiple catalog items in one call; each body item carries the `id`of the item to update. They persist with a single save.
         param body: The request body
@@ -85,7 +107,18 @@ class BulkRequestBuilder(BaseRequestBuilder):
 
         return await self.request_adapter.send_async(request_info, MovingLoadTravelPathBulkResult, error_mapping)
     
-    async def post(self,body: list[MovingLoadTravelPathCreate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPostQueryParameters]] = None) -> Optional[MovingLoadTravelPathBulkResult]:
+    # --- @overload added by regen_python_inits.py ---
+    @overload
+    async def post(
+        self,
+        body: list[MovingLoadTravelPathCreate],
+        *,
+        continue_on_error: Optional[bool] = None,
+    ) -> Optional[MovingLoadTravelPathBulkResult]: ...
+    @overload
+    async def post(self, body: list[MovingLoadTravelPathCreate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPostQueryParameters]] = None) -> Optional[MovingLoadTravelPathBulkResult]: ...
+    # --- end overloads ---
+    async def post(self,body: list[MovingLoadTravelPathCreate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPostQueryParameters]] = None, **kwargs) -> Optional[MovingLoadTravelPathBulkResult]:
         """
         Creates multiple catalog items in one call; they persist with a single save.
         param body: The request body

--- a/sdks/python/client/space_gass_api/generated/job/loads/moving_loads/vehicles/bulk/bulk_request_builder.py
+++ b/sdks/python/client/space_gass_api/generated/job/loads/moving_loads/vehicles/bulk/bulk_request_builder.py
@@ -10,7 +10,7 @@ from kiota_abstractions.request_adapter import RequestAdapter
 from kiota_abstractions.request_information import RequestInformation
 from kiota_abstractions.request_option import RequestOption
 from kiota_abstractions.serialization import Parsable, ParsableFactory
-from typing import Any, Optional, TYPE_CHECKING, Union
+from typing import Any, Optional, TYPE_CHECKING, Union, overload
 from warnings import warn
 
 if TYPE_CHECKING:
@@ -33,7 +33,18 @@ class BulkRequestBuilder(BaseRequestBuilder):
         """
         super().__init__(request_adapter, "{+baseurl}/job/loads/moving-loads/vehicles/bulk{?continueOnError*}", path_parameters)
     
-    async def delete(self,body: list[int], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderDeleteQueryParameters]] = None) -> Optional[BulkDeletedBulkResult]:
+    # --- @overload added by regen_python_inits.py ---
+    @overload
+    async def delete(
+        self,
+        body: list[int],
+        *,
+        continue_on_error: Optional[bool] = None,
+    ) -> Optional[BulkDeletedBulkResult]: ...
+    @overload
+    async def delete(self, body: list[int], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderDeleteQueryParameters]] = None) -> Optional[BulkDeletedBulkResult]: ...
+    # --- end overloads ---
+    async def delete(self,body: list[int], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderDeleteQueryParameters]] = None, **kwargs) -> Optional[BulkDeletedBulkResult]:
         """
         Deletes multiple catalog items by Id. The body is a JSON array of integer Ids(e.g. `[1, 5, 10]`). An item referenced by a scenario load fails with an in-use errorrather than being deleted.
         param body: The request body
@@ -59,7 +70,18 @@ class BulkRequestBuilder(BaseRequestBuilder):
 
         return await self.request_adapter.send_async(request_info, BulkDeletedBulkResult, error_mapping)
     
-    async def patch(self,body: list[MovingLoadVehicleUpdate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPatchQueryParameters]] = None) -> Optional[MovingLoadVehicleBulkResult]:
+    # --- @overload added by regen_python_inits.py ---
+    @overload
+    async def patch(
+        self,
+        body: list[MovingLoadVehicleUpdate],
+        *,
+        continue_on_error: Optional[bool] = None,
+    ) -> Optional[MovingLoadVehicleBulkResult]: ...
+    @overload
+    async def patch(self, body: list[MovingLoadVehicleUpdate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPatchQueryParameters]] = None) -> Optional[MovingLoadVehicleBulkResult]: ...
+    # --- end overloads ---
+    async def patch(self,body: list[MovingLoadVehicleUpdate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPatchQueryParameters]] = None, **kwargs) -> Optional[MovingLoadVehicleBulkResult]:
         """
         Partially updates multiple catalog items in one call; each body item carries the `id`of the item to update. They persist with a single save.
         param body: The request body
@@ -85,7 +107,18 @@ class BulkRequestBuilder(BaseRequestBuilder):
 
         return await self.request_adapter.send_async(request_info, MovingLoadVehicleBulkResult, error_mapping)
     
-    async def post(self,body: list[MovingLoadVehicleCreate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPostQueryParameters]] = None) -> Optional[MovingLoadVehicleBulkResult]:
+    # --- @overload added by regen_python_inits.py ---
+    @overload
+    async def post(
+        self,
+        body: list[MovingLoadVehicleCreate],
+        *,
+        continue_on_error: Optional[bool] = None,
+    ) -> Optional[MovingLoadVehicleBulkResult]: ...
+    @overload
+    async def post(self, body: list[MovingLoadVehicleCreate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPostQueryParameters]] = None) -> Optional[MovingLoadVehicleBulkResult]: ...
+    # --- end overloads ---
+    async def post(self,body: list[MovingLoadVehicleCreate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPostQueryParameters]] = None, **kwargs) -> Optional[MovingLoadVehicleBulkResult]:
         """
         Creates multiple catalog items in one call; they persist with a single save.
         param body: The request body

--- a/sdks/python/client/space_gass_api/generated/job/loads/node_displacements/bulk/bulk_request_builder.py
+++ b/sdks/python/client/space_gass_api/generated/job/loads/node_displacements/bulk/bulk_request_builder.py
@@ -10,7 +10,7 @@ from kiota_abstractions.request_adapter import RequestAdapter
 from kiota_abstractions.request_information import RequestInformation
 from kiota_abstractions.request_option import RequestOption
 from kiota_abstractions.serialization import Parsable, ParsableFactory
-from typing import Any, Optional, TYPE_CHECKING, Union
+from typing import Any, Optional, TYPE_CHECKING, Union, overload
 from warnings import warn
 
 if TYPE_CHECKING:
@@ -34,7 +34,18 @@ class BulkRequestBuilder(BaseRequestBuilder):
         """
         super().__init__(request_adapter, "{+baseurl}/job/loads/node-displacements/bulk{?continueOnError*}", path_parameters)
     
-    async def delete(self,body: list[PrescribedDisplacementKey], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderDeleteQueryParameters]] = None) -> Optional[PrescribedDisplacementKeyBulkResult]:
+    # --- @overload added by regen_python_inits.py ---
+    @overload
+    async def delete(
+        self,
+        body: list[PrescribedDisplacementKey],
+        *,
+        continue_on_error: Optional[bool] = None,
+    ) -> Optional[PrescribedDisplacementKeyBulkResult]: ...
+    @overload
+    async def delete(self, body: list[PrescribedDisplacementKey], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderDeleteQueryParameters]] = None) -> Optional[PrescribedDisplacementKeyBulkResult]: ...
+    # --- end overloads ---
+    async def delete(self,body: list[PrescribedDisplacementKey], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderDeleteQueryParameters]] = None, **kwargs) -> Optional[PrescribedDisplacementKeyBulkResult]:
         """
         Deletes multiple prescribed displacements. Both case and node are required for each entry —providing only a case does not delete all displacements for that case.The succeeded array echoes back the Ids of each successfully deleted displacement.
         param body: The request body
@@ -60,7 +71,18 @@ class BulkRequestBuilder(BaseRequestBuilder):
 
         return await self.request_adapter.send_async(request_info, PrescribedDisplacementKeyBulkResult, error_mapping)
     
-    async def patch(self,body: list[PrescribedDisplacementUpdate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPatchQueryParameters]] = None) -> Optional[PrescribedDisplacementBulkResult]:
+    # --- @overload added by regen_python_inits.py ---
+    @overload
+    async def patch(
+        self,
+        body: list[PrescribedDisplacementUpdate],
+        *,
+        continue_on_error: Optional[bool] = None,
+    ) -> Optional[PrescribedDisplacementBulkResult]: ...
+    @overload
+    async def patch(self, body: list[PrescribedDisplacementUpdate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPatchQueryParameters]] = None) -> Optional[PrescribedDisplacementBulkResult]: ...
+    # --- end overloads ---
+    async def patch(self,body: list[PrescribedDisplacementUpdate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPatchQueryParameters]] = None, **kwargs) -> Optional[PrescribedDisplacementBulkResult]:
         """
         Updates multiple prescribed displacements. Each item must include case and node in the body.All load cases referenced must be Primary.
         param body: The request body
@@ -86,7 +108,18 @@ class BulkRequestBuilder(BaseRequestBuilder):
 
         return await self.request_adapter.send_async(request_info, PrescribedDisplacementBulkResult, error_mapping)
     
-    async def post(self,body: list[PrescribedDisplacementCreate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPostQueryParameters]] = None) -> Optional[PrescribedDisplacementBulkResult]:
+    # --- @overload added by regen_python_inits.py ---
+    @overload
+    async def post(
+        self,
+        body: list[PrescribedDisplacementCreate],
+        *,
+        continue_on_error: Optional[bool] = None,
+    ) -> Optional[PrescribedDisplacementBulkResult]: ...
+    @overload
+    async def post(self, body: list[PrescribedDisplacementCreate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPostQueryParameters]] = None) -> Optional[PrescribedDisplacementBulkResult]: ...
+    # --- end overloads ---
+    async def post(self,body: list[PrescribedDisplacementCreate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPostQueryParameters]] = None, **kwargs) -> Optional[PrescribedDisplacementBulkResult]:
         """
         Creates multiple loads in a bulk operation.All load cases referenced must exist and be Primary load cases.
         param body: The request body

--- a/sdks/python/client/space_gass_api/generated/job/loads/node_loads/bulk/bulk_request_builder.py
+++ b/sdks/python/client/space_gass_api/generated/job/loads/node_loads/bulk/bulk_request_builder.py
@@ -10,7 +10,7 @@ from kiota_abstractions.request_adapter import RequestAdapter
 from kiota_abstractions.request_information import RequestInformation
 from kiota_abstractions.request_option import RequestOption
 from kiota_abstractions.serialization import Parsable, ParsableFactory
-from typing import Any, Optional, TYPE_CHECKING, Union
+from typing import Any, Optional, TYPE_CHECKING, Union, overload
 from warnings import warn
 
 if TYPE_CHECKING:
@@ -34,7 +34,18 @@ class BulkRequestBuilder(BaseRequestBuilder):
         """
         super().__init__(request_adapter, "{+baseurl}/job/loads/node-loads/bulk{?continueOnError*}", path_parameters)
     
-    async def delete(self,body: list[NodeLoadKey], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderDeleteQueryParameters]] = None) -> Optional[NodeLoadKeyBulkResult]:
+    # --- @overload added by regen_python_inits.py ---
+    @overload
+    async def delete(
+        self,
+        body: list[NodeLoadKey],
+        *,
+        continue_on_error: Optional[bool] = None,
+    ) -> Optional[NodeLoadKeyBulkResult]: ...
+    @overload
+    async def delete(self, body: list[NodeLoadKey], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderDeleteQueryParameters]] = None) -> Optional[NodeLoadKeyBulkResult]: ...
+    # --- end overloads ---
+    async def delete(self,body: list[NodeLoadKey], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderDeleteQueryParameters]] = None, **kwargs) -> Optional[NodeLoadKeyBulkResult]:
         """
         Deletes multiple node loads. Both case and node are required for each entry —providing only a case does not delete all loads for that case.The succeeded array echoes back the Ids of each successfully deleted load.
         param body: The request body
@@ -60,7 +71,18 @@ class BulkRequestBuilder(BaseRequestBuilder):
 
         return await self.request_adapter.send_async(request_info, NodeLoadKeyBulkResult, error_mapping)
     
-    async def patch(self,body: list[NodeLoadUpdate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPatchQueryParameters]] = None) -> Optional[NodeLoadBulkResult]:
+    # --- @overload added by regen_python_inits.py ---
+    @overload
+    async def patch(
+        self,
+        body: list[NodeLoadUpdate],
+        *,
+        continue_on_error: Optional[bool] = None,
+    ) -> Optional[NodeLoadBulkResult]: ...
+    @overload
+    async def patch(self, body: list[NodeLoadUpdate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPatchQueryParameters]] = None) -> Optional[NodeLoadBulkResult]: ...
+    # --- end overloads ---
+    async def patch(self,body: list[NodeLoadUpdate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPatchQueryParameters]] = None, **kwargs) -> Optional[NodeLoadBulkResult]:
         """
         Updates multiple node loads. Each item must include case and node in the body.All load cases referenced must be Primary.
         param body: The request body
@@ -86,7 +108,18 @@ class BulkRequestBuilder(BaseRequestBuilder):
 
         return await self.request_adapter.send_async(request_info, NodeLoadBulkResult, error_mapping)
     
-    async def post(self,body: list[NodeLoadCreate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPostQueryParameters]] = None) -> Optional[NodeLoadBulkResult]:
+    # --- @overload added by regen_python_inits.py ---
+    @overload
+    async def post(
+        self,
+        body: list[NodeLoadCreate],
+        *,
+        continue_on_error: Optional[bool] = None,
+    ) -> Optional[NodeLoadBulkResult]: ...
+    @overload
+    async def post(self, body: list[NodeLoadCreate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPostQueryParameters]] = None) -> Optional[NodeLoadBulkResult]: ...
+    # --- end overloads ---
+    async def post(self,body: list[NodeLoadCreate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPostQueryParameters]] = None, **kwargs) -> Optional[NodeLoadBulkResult]:
         """
         Creates multiple loads in a bulk operation.All load cases referenced must exist and be Primary load cases.
         param body: The request body

--- a/sdks/python/client/space_gass_api/generated/job/loads/plate_pressure_loads/bulk/bulk_request_builder.py
+++ b/sdks/python/client/space_gass_api/generated/job/loads/plate_pressure_loads/bulk/bulk_request_builder.py
@@ -10,7 +10,7 @@ from kiota_abstractions.request_adapter import RequestAdapter
 from kiota_abstractions.request_information import RequestInformation
 from kiota_abstractions.request_option import RequestOption
 from kiota_abstractions.serialization import Parsable, ParsableFactory
-from typing import Any, Optional, TYPE_CHECKING, Union
+from typing import Any, Optional, TYPE_CHECKING, Union, overload
 from warnings import warn
 
 if TYPE_CHECKING:
@@ -34,7 +34,18 @@ class BulkRequestBuilder(BaseRequestBuilder):
         """
         super().__init__(request_adapter, "{+baseurl}/job/loads/plate-pressure-loads/bulk{?continueOnError*}", path_parameters)
     
-    async def delete(self,body: list[PlatePressureLoadKey], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderDeleteQueryParameters]] = None) -> Optional[PlatePressureLoadKeyBulkResult]:
+    # --- @overload added by regen_python_inits.py ---
+    @overload
+    async def delete(
+        self,
+        body: list[PlatePressureLoadKey],
+        *,
+        continue_on_error: Optional[bool] = None,
+    ) -> Optional[PlatePressureLoadKeyBulkResult]: ...
+    @overload
+    async def delete(self, body: list[PlatePressureLoadKey], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderDeleteQueryParameters]] = None) -> Optional[PlatePressureLoadKeyBulkResult]: ...
+    # --- end overloads ---
+    async def delete(self,body: list[PlatePressureLoadKey], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderDeleteQueryParameters]] = None, **kwargs) -> Optional[PlatePressureLoadKeyBulkResult]:
         """
         Deletes multiple plate pressure loads. Both case and plate are required for each entry —providing only a case does not delete all pressure loads for that case.The succeeded array echoes back the Ids of each successfully deleted load.
         param body: The request body
@@ -60,7 +71,18 @@ class BulkRequestBuilder(BaseRequestBuilder):
 
         return await self.request_adapter.send_async(request_info, PlatePressureLoadKeyBulkResult, error_mapping)
     
-    async def patch(self,body: list[PlatePressureLoadUpdate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPatchQueryParameters]] = None) -> Optional[PlatePressureLoadBulkResult]:
+    # --- @overload added by regen_python_inits.py ---
+    @overload
+    async def patch(
+        self,
+        body: list[PlatePressureLoadUpdate],
+        *,
+        continue_on_error: Optional[bool] = None,
+    ) -> Optional[PlatePressureLoadBulkResult]: ...
+    @overload
+    async def patch(self, body: list[PlatePressureLoadUpdate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPatchQueryParameters]] = None) -> Optional[PlatePressureLoadBulkResult]: ...
+    # --- end overloads ---
+    async def patch(self,body: list[PlatePressureLoadUpdate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPatchQueryParameters]] = None, **kwargs) -> Optional[PlatePressureLoadBulkResult]:
         """
         Updates multiple plate pressure loads. Each item must include case and plate in the body.All load cases referenced must be Primary.
         param body: The request body
@@ -86,7 +108,18 @@ class BulkRequestBuilder(BaseRequestBuilder):
 
         return await self.request_adapter.send_async(request_info, PlatePressureLoadBulkResult, error_mapping)
     
-    async def post(self,body: list[PlatePressureLoadCreate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPostQueryParameters]] = None) -> Optional[PlatePressureLoadBulkResult]:
+    # --- @overload added by regen_python_inits.py ---
+    @overload
+    async def post(
+        self,
+        body: list[PlatePressureLoadCreate],
+        *,
+        continue_on_error: Optional[bool] = None,
+    ) -> Optional[PlatePressureLoadBulkResult]: ...
+    @overload
+    async def post(self, body: list[PlatePressureLoadCreate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPostQueryParameters]] = None) -> Optional[PlatePressureLoadBulkResult]: ...
+    # --- end overloads ---
+    async def post(self,body: list[PlatePressureLoadCreate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPostQueryParameters]] = None, **kwargs) -> Optional[PlatePressureLoadBulkResult]:
         """
         Creates multiple loads in a bulk operation.All load cases referenced must exist and be Primary load cases.
         param body: The request body

--- a/sdks/python/client/space_gass_api/generated/job/loads/self_weight_loads/bulk/bulk_request_builder.py
+++ b/sdks/python/client/space_gass_api/generated/job/loads/self_weight_loads/bulk/bulk_request_builder.py
@@ -10,7 +10,7 @@ from kiota_abstractions.request_adapter import RequestAdapter
 from kiota_abstractions.request_information import RequestInformation
 from kiota_abstractions.request_option import RequestOption
 from kiota_abstractions.serialization import Parsable, ParsableFactory
-from typing import Any, Optional, TYPE_CHECKING, Union
+from typing import Any, Optional, TYPE_CHECKING, Union, overload
 from warnings import warn
 
 if TYPE_CHECKING:
@@ -31,7 +31,18 @@ class BulkRequestBuilder(BaseRequestBuilder):
         """
         super().__init__(request_adapter, "{+baseurl}/job/loads/self-weight-loads/bulk{?continueOnError*}", path_parameters)
     
-    async def post(self,body: list[SelfWeightLoadCreate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPostQueryParameters]] = None) -> Optional[SelfWeightLoadBulkResult]:
+    # --- @overload added by regen_python_inits.py ---
+    @overload
+    async def post(
+        self,
+        body: list[SelfWeightLoadCreate],
+        *,
+        continue_on_error: Optional[bool] = None,
+    ) -> Optional[SelfWeightLoadBulkResult]: ...
+    @overload
+    async def post(self, body: list[SelfWeightLoadCreate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPostQueryParameters]] = None) -> Optional[SelfWeightLoadBulkResult]: ...
+    # --- end overloads ---
+    async def post(self,body: list[SelfWeightLoadCreate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPostQueryParameters]] = None, **kwargs) -> Optional[SelfWeightLoadBulkResult]:
         """
         Creates multiple loads in a bulk operation.All load cases referenced must exist and be Primary load cases.
         param body: The request body

--- a/sdks/python/client/space_gass_api/generated/job/loads/thermal_loads/bulk/bulk_request_builder.py
+++ b/sdks/python/client/space_gass_api/generated/job/loads/thermal_loads/bulk/bulk_request_builder.py
@@ -10,7 +10,7 @@ from kiota_abstractions.request_adapter import RequestAdapter
 from kiota_abstractions.request_information import RequestInformation
 from kiota_abstractions.request_option import RequestOption
 from kiota_abstractions.serialization import Parsable, ParsableFactory
-from typing import Any, Optional, TYPE_CHECKING, Union
+from typing import Any, Optional, TYPE_CHECKING, Union, overload
 from warnings import warn
 
 if TYPE_CHECKING:
@@ -34,7 +34,18 @@ class BulkRequestBuilder(BaseRequestBuilder):
         """
         super().__init__(request_adapter, "{+baseurl}/job/loads/thermal-loads/bulk{?continueOnError*}", path_parameters)
     
-    async def delete(self,body: list[ThermalLoadElementId], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderDeleteQueryParameters]] = None) -> Optional[ThermalLoadElementIdBulkResult]:
+    # --- @overload added by regen_python_inits.py ---
+    @overload
+    async def delete(
+        self,
+        body: list[ThermalLoadElementId],
+        *,
+        continue_on_error: Optional[bool] = None,
+    ) -> Optional[ThermalLoadElementIdBulkResult]: ...
+    @overload
+    async def delete(self, body: list[ThermalLoadElementId], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderDeleteQueryParameters]] = None) -> Optional[ThermalLoadElementIdBulkResult]: ...
+    # --- end overloads ---
+    async def delete(self,body: list[ThermalLoadElementId], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderDeleteQueryParameters]] = None, **kwargs) -> Optional[ThermalLoadElementIdBulkResult]:
         """
         Deletes multiple thermal loads. Case, element, and elementType are all required for each entry.The succeeded array echoes back the Ids of each successfully deleted load.
         param body: The request body
@@ -60,7 +71,18 @@ class BulkRequestBuilder(BaseRequestBuilder):
 
         return await self.request_adapter.send_async(request_info, ThermalLoadElementIdBulkResult, error_mapping)
     
-    async def patch(self,body: list[ThermalLoadUpdate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPatchQueryParameters]] = None) -> Optional[ThermalLoadBulkResult]:
+    # --- @overload added by regen_python_inits.py ---
+    @overload
+    async def patch(
+        self,
+        body: list[ThermalLoadUpdate],
+        *,
+        continue_on_error: Optional[bool] = None,
+    ) -> Optional[ThermalLoadBulkResult]: ...
+    @overload
+    async def patch(self, body: list[ThermalLoadUpdate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPatchQueryParameters]] = None) -> Optional[ThermalLoadBulkResult]: ...
+    # --- end overloads ---
+    async def patch(self,body: list[ThermalLoadUpdate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPatchQueryParameters]] = None, **kwargs) -> Optional[ThermalLoadBulkResult]:
         """
         Updates multiple thermal loads. Each item must include case, element, and elementType in the body.All load cases referenced must be Primary.
         param body: The request body
@@ -86,7 +108,18 @@ class BulkRequestBuilder(BaseRequestBuilder):
 
         return await self.request_adapter.send_async(request_info, ThermalLoadBulkResult, error_mapping)
     
-    async def post(self,body: list[ThermalLoadCreate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPostQueryParameters]] = None) -> Optional[ThermalLoadBulkResult]:
+    # --- @overload added by regen_python_inits.py ---
+    @overload
+    async def post(
+        self,
+        body: list[ThermalLoadCreate],
+        *,
+        continue_on_error: Optional[bool] = None,
+    ) -> Optional[ThermalLoadBulkResult]: ...
+    @overload
+    async def post(self, body: list[ThermalLoadCreate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPostQueryParameters]] = None) -> Optional[ThermalLoadBulkResult]: ...
+    # --- end overloads ---
+    async def post(self,body: list[ThermalLoadCreate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPostQueryParameters]] = None, **kwargs) -> Optional[ThermalLoadBulkResult]:
         """
         Creates multiple loads in a bulk operation.All load cases referenced must exist and be Primary load cases.
         param body: The request body

--- a/sdks/python/client/space_gass_api/generated/job/structure/materials/bulk/bulk_request_builder.py
+++ b/sdks/python/client/space_gass_api/generated/job/structure/materials/bulk/bulk_request_builder.py
@@ -10,7 +10,7 @@ from kiota_abstractions.request_adapter import RequestAdapter
 from kiota_abstractions.request_information import RequestInformation
 from kiota_abstractions.request_option import RequestOption
 from kiota_abstractions.serialization import Parsable, ParsableFactory
-from typing import Any, Optional, TYPE_CHECKING, Union
+from typing import Any, Optional, TYPE_CHECKING, Union, overload
 from warnings import warn
 
 if TYPE_CHECKING:
@@ -33,7 +33,18 @@ class BulkRequestBuilder(BaseRequestBuilder):
         """
         super().__init__(request_adapter, "{+baseurl}/job/structure/materials/bulk{?continueOnError*}", path_parameters)
     
-    async def delete(self,body: list[int], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderDeleteQueryParameters]] = None) -> Optional[BulkDeletedBulkResult]:
+    # --- @overload added by regen_python_inits.py ---
+    @overload
+    async def delete(
+        self,
+        body: list[int],
+        *,
+        continue_on_error: Optional[bool] = None,
+    ) -> Optional[BulkDeletedBulkResult]: ...
+    @overload
+    async def delete(self, body: list[int], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderDeleteQueryParameters]] = None) -> Optional[BulkDeletedBulkResult]: ...
+    # --- end overloads ---
+    async def delete(self,body: list[int], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderDeleteQueryParameters]] = None, **kwargs) -> Optional[BulkDeletedBulkResult]:
         """
         Deletes multiple entities by Id. The body is a JSON array of integer Ids(e.g. `[1, 5, 10]`) — consistent with every other bulk-delete endpointin the API (see CLAUDE.md "Query Parameter Conventions").            For cascading entities (Nodes, Members, Plates), `continueOnError` governs only theper-Id existence pre-check: a missing Id is reported and, when `false`, aborts thebatch. The cascade itself is planned and executed as a single unit — if cleanup failsmid-execution the entire batch is rolled back (affected datasheets are reloaded), so nopartial cascade is persisted.
         param body: The request body
@@ -59,7 +70,18 @@ class BulkRequestBuilder(BaseRequestBuilder):
 
         return await self.request_adapter.send_async(request_info, BulkDeletedBulkResult, error_mapping)
     
-    async def patch(self,body: list[MaterialUpdate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPatchQueryParameters]] = None) -> Optional[MaterialBulkResult]:
+    # --- @overload added by regen_python_inits.py ---
+    @overload
+    async def patch(
+        self,
+        body: list[MaterialUpdate],
+        *,
+        continue_on_error: Optional[bool] = None,
+    ) -> Optional[MaterialBulkResult]: ...
+    @overload
+    async def patch(self, body: list[MaterialUpdate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPatchQueryParameters]] = None) -> Optional[MaterialBulkResult]: ...
+    # --- end overloads ---
+    async def patch(self,body: list[MaterialUpdate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPatchQueryParameters]] = None, **kwargs) -> Optional[MaterialBulkResult]:
         """
         Updates multiple items in a bulk operation.Each item must include its Id in the request body.If a validator is registered, all items are validated upfront before any are updated.
         param body: The request body
@@ -85,7 +107,18 @@ class BulkRequestBuilder(BaseRequestBuilder):
 
         return await self.request_adapter.send_async(request_info, MaterialBulkResult, error_mapping)
     
-    async def post(self,body: list[MaterialUserCreate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPostQueryParameters]] = None) -> Optional[MaterialBulkResult]:
+    # --- @overload added by regen_python_inits.py ---
+    @overload
+    async def post(
+        self,
+        body: list[MaterialUserCreate],
+        *,
+        continue_on_error: Optional[bool] = None,
+    ) -> Optional[MaterialBulkResult]: ...
+    @overload
+    async def post(self, body: list[MaterialUserCreate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPostQueryParameters]] = None) -> Optional[MaterialBulkResult]: ...
+    # --- end overloads ---
+    async def post(self,body: list[MaterialUserCreate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPostQueryParameters]] = None, **kwargs) -> Optional[MaterialBulkResult]:
         """
         Creates multiple items in a bulk operation.If a validator is registered, all items are validated upfront before any are created.
         param body: The request body

--- a/sdks/python/client/space_gass_api/generated/job/structure/materials/library/bulk/bulk_request_builder.py
+++ b/sdks/python/client/space_gass_api/generated/job/structure/materials/library/bulk/bulk_request_builder.py
@@ -10,7 +10,7 @@ from kiota_abstractions.request_adapter import RequestAdapter
 from kiota_abstractions.request_information import RequestInformation
 from kiota_abstractions.request_option import RequestOption
 from kiota_abstractions.serialization import Parsable, ParsableFactory
-from typing import Any, Optional, TYPE_CHECKING, Union
+from typing import Any, Optional, TYPE_CHECKING, Union, overload
 from warnings import warn
 
 if TYPE_CHECKING:
@@ -31,7 +31,18 @@ class BulkRequestBuilder(BaseRequestBuilder):
         """
         super().__init__(request_adapter, "{+baseurl}/job/structure/materials/library/bulk{?continueOnError*}", path_parameters)
     
-    async def post(self,body: list[MaterialLibraryCreate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPostQueryParameters]] = None) -> Optional[MaterialBulkResult]:
+    # --- @overload added by regen_python_inits.py ---
+    @overload
+    async def post(
+        self,
+        body: list[MaterialLibraryCreate],
+        *,
+        continue_on_error: Optional[bool] = None,
+    ) -> Optional[MaterialBulkResult]: ...
+    @overload
+    async def post(self, body: list[MaterialLibraryCreate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPostQueryParameters]] = None) -> Optional[MaterialBulkResult]: ...
+    # --- end overloads ---
+    async def post(self,body: list[MaterialLibraryCreate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPostQueryParameters]] = None, **kwargs) -> Optional[MaterialBulkResult]:
         """
         Creates multiple library-sourced materials in a single request. Each material isresolved from the SPACE GASS material library by (name, library).
         param body: The request body

--- a/sdks/python/client/space_gass_api/generated/job/structure/member_offsets/bulk/bulk_request_builder.py
+++ b/sdks/python/client/space_gass_api/generated/job/structure/member_offsets/bulk/bulk_request_builder.py
@@ -10,7 +10,7 @@ from kiota_abstractions.request_adapter import RequestAdapter
 from kiota_abstractions.request_information import RequestInformation
 from kiota_abstractions.request_option import RequestOption
 from kiota_abstractions.serialization import Parsable, ParsableFactory
-from typing import Any, Optional, TYPE_CHECKING, Union
+from typing import Any, Optional, TYPE_CHECKING, Union, overload
 from warnings import warn
 
 if TYPE_CHECKING:
@@ -33,7 +33,18 @@ class BulkRequestBuilder(BaseRequestBuilder):
         """
         super().__init__(request_adapter, "{+baseurl}/job/structure/member-offsets/bulk{?continueOnError*}", path_parameters)
     
-    async def delete(self,body: list[int], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderDeleteQueryParameters]] = None) -> Optional[BulkDeletedBulkResult]:
+    # --- @overload added by regen_python_inits.py ---
+    @overload
+    async def delete(
+        self,
+        body: list[int],
+        *,
+        continue_on_error: Optional[bool] = None,
+    ) -> Optional[BulkDeletedBulkResult]: ...
+    @overload
+    async def delete(self, body: list[int], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderDeleteQueryParameters]] = None) -> Optional[BulkDeletedBulkResult]: ...
+    # --- end overloads ---
+    async def delete(self,body: list[int], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderDeleteQueryParameters]] = None, **kwargs) -> Optional[BulkDeletedBulkResult]:
         """
         Deletes multiple attribute rows by parent Id. The body is a JSON array of integer parent Ids.
         param body: The request body
@@ -59,7 +70,18 @@ class BulkRequestBuilder(BaseRequestBuilder):
 
         return await self.request_adapter.send_async(request_info, BulkDeletedBulkResult, error_mapping)
     
-    async def patch(self,body: list[MemberOffsetUpdate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPatchQueryParameters]] = None) -> Optional[MemberOffsetBulkResult]:
+    # --- @overload added by regen_python_inits.py ---
+    @overload
+    async def patch(
+        self,
+        body: list[MemberOffsetUpdate],
+        *,
+        continue_on_error: Optional[bool] = None,
+    ) -> Optional[MemberOffsetBulkResult]: ...
+    @overload
+    async def patch(self, body: list[MemberOffsetUpdate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPatchQueryParameters]] = None) -> Optional[MemberOffsetBulkResult]: ...
+    # --- end overloads ---
+    async def patch(self,body: list[MemberOffsetUpdate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPatchQueryParameters]] = None, **kwargs) -> Optional[MemberOffsetBulkResult]:
         """
         Updates multiple attribute rows in a single request. Each item must include its parent Id.Per-item 404 reported as a bulk error if no row exists for the supplied parent.
         param body: The request body
@@ -85,7 +107,18 @@ class BulkRequestBuilder(BaseRequestBuilder):
 
         return await self.request_adapter.send_async(request_info, MemberOffsetBulkResult, error_mapping)
     
-    async def post(self,body: list[MemberOffsetCreate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPostQueryParameters]] = None) -> Optional[MemberOffsetBulkResult]:
+    # --- @overload added by regen_python_inits.py ---
+    @overload
+    async def post(
+        self,
+        body: list[MemberOffsetCreate],
+        *,
+        continue_on_error: Optional[bool] = None,
+    ) -> Optional[MemberOffsetBulkResult]: ...
+    @overload
+    async def post(self, body: list[MemberOffsetCreate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPostQueryParameters]] = None) -> Optional[MemberOffsetBulkResult]: ...
+    # --- end overloads ---
+    async def post(self,body: list[MemberOffsetCreate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPostQueryParameters]] = None, **kwargs) -> Optional[MemberOffsetBulkResult]:
         """
         Creates multiple attribute rows in a single request. Each item must include its parent Idin the body. Returns 409 (per-item error) for any row whose parent already has an attribute.
         param body: The request body

--- a/sdks/python/client/space_gass_api/generated/job/structure/members/bulk/bulk_request_builder.py
+++ b/sdks/python/client/space_gass_api/generated/job/structure/members/bulk/bulk_request_builder.py
@@ -10,7 +10,7 @@ from kiota_abstractions.request_adapter import RequestAdapter
 from kiota_abstractions.request_information import RequestInformation
 from kiota_abstractions.request_option import RequestOption
 from kiota_abstractions.serialization import Parsable, ParsableFactory
-from typing import Any, Optional, TYPE_CHECKING, Union
+from typing import Any, Optional, TYPE_CHECKING, Union, overload
 from warnings import warn
 
 if TYPE_CHECKING:
@@ -33,7 +33,18 @@ class BulkRequestBuilder(BaseRequestBuilder):
         """
         super().__init__(request_adapter, "{+baseurl}/job/structure/members/bulk{?continueOnError*}", path_parameters)
     
-    async def delete(self,body: list[int], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderDeleteQueryParameters]] = None) -> Optional[BulkDeletedBulkResult]:
+    # --- @overload added by regen_python_inits.py ---
+    @overload
+    async def delete(
+        self,
+        body: list[int],
+        *,
+        continue_on_error: Optional[bool] = None,
+    ) -> Optional[BulkDeletedBulkResult]: ...
+    @overload
+    async def delete(self, body: list[int], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderDeleteQueryParameters]] = None) -> Optional[BulkDeletedBulkResult]: ...
+    # --- end overloads ---
+    async def delete(self,body: list[int], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderDeleteQueryParameters]] = None, **kwargs) -> Optional[BulkDeletedBulkResult]:
         """
         Deletes multiple entities by Id. The body is a JSON array of integer Ids(e.g. `[1, 5, 10]`) — consistent with every other bulk-delete endpointin the API (see CLAUDE.md "Query Parameter Conventions").            For cascading entities (Nodes, Members, Plates), `continueOnError` governs only theper-Id existence pre-check: a missing Id is reported and, when `false`, aborts thebatch. The cascade itself is planned and executed as a single unit — if cleanup failsmid-execution the entire batch is rolled back (affected datasheets are reloaded), so nopartial cascade is persisted.
         param body: The request body
@@ -59,7 +70,18 @@ class BulkRequestBuilder(BaseRequestBuilder):
 
         return await self.request_adapter.send_async(request_info, BulkDeletedBulkResult, error_mapping)
     
-    async def patch(self,body: list[MemberUpdate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPatchQueryParameters]] = None) -> Optional[MemberBulkResult]:
+    # --- @overload added by regen_python_inits.py ---
+    @overload
+    async def patch(
+        self,
+        body: list[MemberUpdate],
+        *,
+        continue_on_error: Optional[bool] = None,
+    ) -> Optional[MemberBulkResult]: ...
+    @overload
+    async def patch(self, body: list[MemberUpdate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPatchQueryParameters]] = None) -> Optional[MemberBulkResult]: ...
+    # --- end overloads ---
+    async def patch(self,body: list[MemberUpdate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPatchQueryParameters]] = None, **kwargs) -> Optional[MemberBulkResult]:
         """
         Updates multiple items in a bulk operation.Each item must include its Id in the request body.If a validator is registered, all items are validated upfront before any are updated.
         param body: The request body
@@ -85,7 +107,18 @@ class BulkRequestBuilder(BaseRequestBuilder):
 
         return await self.request_adapter.send_async(request_info, MemberBulkResult, error_mapping)
     
-    async def post(self,body: list[MemberCreate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPostQueryParameters]] = None) -> Optional[MemberBulkResult]:
+    # --- @overload added by regen_python_inits.py ---
+    @overload
+    async def post(
+        self,
+        body: list[MemberCreate],
+        *,
+        continue_on_error: Optional[bool] = None,
+    ) -> Optional[MemberBulkResult]: ...
+    @overload
+    async def post(self, body: list[MemberCreate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPostQueryParameters]] = None) -> Optional[MemberBulkResult]: ...
+    # --- end overloads ---
+    async def post(self,body: list[MemberCreate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPostQueryParameters]] = None, **kwargs) -> Optional[MemberBulkResult]:
         """
         Creates multiple items in a bulk operation.If a validator is registered, all items are validated upfront before any are created.
         param body: The request body

--- a/sdks/python/client/space_gass_api/generated/job/structure/node_constraints/bulk/bulk_request_builder.py
+++ b/sdks/python/client/space_gass_api/generated/job/structure/node_constraints/bulk/bulk_request_builder.py
@@ -10,7 +10,7 @@ from kiota_abstractions.request_adapter import RequestAdapter
 from kiota_abstractions.request_information import RequestInformation
 from kiota_abstractions.request_option import RequestOption
 from kiota_abstractions.serialization import Parsable, ParsableFactory
-from typing import Any, Optional, TYPE_CHECKING, Union
+from typing import Any, Optional, TYPE_CHECKING, Union, overload
 from warnings import warn
 
 if TYPE_CHECKING:
@@ -33,7 +33,18 @@ class BulkRequestBuilder(BaseRequestBuilder):
         """
         super().__init__(request_adapter, "{+baseurl}/job/structure/node-constraints/bulk{?continueOnError*}", path_parameters)
     
-    async def delete(self,body: list[int], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderDeleteQueryParameters]] = None) -> Optional[BulkDeletedBulkResult]:
+    # --- @overload added by regen_python_inits.py ---
+    @overload
+    async def delete(
+        self,
+        body: list[int],
+        *,
+        continue_on_error: Optional[bool] = None,
+    ) -> Optional[BulkDeletedBulkResult]: ...
+    @overload
+    async def delete(self, body: list[int], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderDeleteQueryParameters]] = None) -> Optional[BulkDeletedBulkResult]: ...
+    # --- end overloads ---
+    async def delete(self,body: list[int], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderDeleteQueryParameters]] = None, **kwargs) -> Optional[BulkDeletedBulkResult]:
         """
         Deletes multiple attribute rows by parent Id. The body is a JSON array of integer parent Ids.
         param body: The request body
@@ -59,7 +70,18 @@ class BulkRequestBuilder(BaseRequestBuilder):
 
         return await self.request_adapter.send_async(request_info, BulkDeletedBulkResult, error_mapping)
     
-    async def patch(self,body: list[NodeConstraintUpdate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPatchQueryParameters]] = None) -> Optional[NodeConstraintBulkResult]:
+    # --- @overload added by regen_python_inits.py ---
+    @overload
+    async def patch(
+        self,
+        body: list[NodeConstraintUpdate],
+        *,
+        continue_on_error: Optional[bool] = None,
+    ) -> Optional[NodeConstraintBulkResult]: ...
+    @overload
+    async def patch(self, body: list[NodeConstraintUpdate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPatchQueryParameters]] = None) -> Optional[NodeConstraintBulkResult]: ...
+    # --- end overloads ---
+    async def patch(self,body: list[NodeConstraintUpdate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPatchQueryParameters]] = None, **kwargs) -> Optional[NodeConstraintBulkResult]:
         """
         Updates multiple attribute rows in a single request. Each item must include its parent Id.Per-item 404 reported as a bulk error if no row exists for the supplied parent.
         param body: The request body
@@ -85,7 +107,18 @@ class BulkRequestBuilder(BaseRequestBuilder):
 
         return await self.request_adapter.send_async(request_info, NodeConstraintBulkResult, error_mapping)
     
-    async def post(self,body: list[NodeConstraintCreate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPostQueryParameters]] = None) -> Optional[NodeConstraintBulkResult]:
+    # --- @overload added by regen_python_inits.py ---
+    @overload
+    async def post(
+        self,
+        body: list[NodeConstraintCreate],
+        *,
+        continue_on_error: Optional[bool] = None,
+    ) -> Optional[NodeConstraintBulkResult]: ...
+    @overload
+    async def post(self, body: list[NodeConstraintCreate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPostQueryParameters]] = None) -> Optional[NodeConstraintBulkResult]: ...
+    # --- end overloads ---
+    async def post(self,body: list[NodeConstraintCreate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPostQueryParameters]] = None, **kwargs) -> Optional[NodeConstraintBulkResult]:
         """
         Creates multiple attribute rows in a single request. Each item must include its parent Idin the body. Returns 409 (per-item error) for any row whose parent already has an attribute.
         param body: The request body

--- a/sdks/python/client/space_gass_api/generated/job/structure/node_restraints/bulk/bulk_request_builder.py
+++ b/sdks/python/client/space_gass_api/generated/job/structure/node_restraints/bulk/bulk_request_builder.py
@@ -10,7 +10,7 @@ from kiota_abstractions.request_adapter import RequestAdapter
 from kiota_abstractions.request_information import RequestInformation
 from kiota_abstractions.request_option import RequestOption
 from kiota_abstractions.serialization import Parsable, ParsableFactory
-from typing import Any, Optional, TYPE_CHECKING, Union
+from typing import Any, Optional, TYPE_CHECKING, Union, overload
 from warnings import warn
 
 if TYPE_CHECKING:
@@ -33,7 +33,18 @@ class BulkRequestBuilder(BaseRequestBuilder):
         """
         super().__init__(request_adapter, "{+baseurl}/job/structure/node-restraints/bulk{?continueOnError*}", path_parameters)
     
-    async def delete(self,body: list[int], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderDeleteQueryParameters]] = None) -> Optional[BulkDeletedBulkResult]:
+    # --- @overload added by regen_python_inits.py ---
+    @overload
+    async def delete(
+        self,
+        body: list[int],
+        *,
+        continue_on_error: Optional[bool] = None,
+    ) -> Optional[BulkDeletedBulkResult]: ...
+    @overload
+    async def delete(self, body: list[int], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderDeleteQueryParameters]] = None) -> Optional[BulkDeletedBulkResult]: ...
+    # --- end overloads ---
+    async def delete(self,body: list[int], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderDeleteQueryParameters]] = None, **kwargs) -> Optional[BulkDeletedBulkResult]:
         """
         Deletes multiple attribute rows by parent Id. The body is a JSON array of integer parent Ids.
         param body: The request body
@@ -59,7 +70,18 @@ class BulkRequestBuilder(BaseRequestBuilder):
 
         return await self.request_adapter.send_async(request_info, BulkDeletedBulkResult, error_mapping)
     
-    async def patch(self,body: list[NodeRestraintUpdate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPatchQueryParameters]] = None) -> Optional[NodeRestraintBulkResult]:
+    # --- @overload added by regen_python_inits.py ---
+    @overload
+    async def patch(
+        self,
+        body: list[NodeRestraintUpdate],
+        *,
+        continue_on_error: Optional[bool] = None,
+    ) -> Optional[NodeRestraintBulkResult]: ...
+    @overload
+    async def patch(self, body: list[NodeRestraintUpdate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPatchQueryParameters]] = None) -> Optional[NodeRestraintBulkResult]: ...
+    # --- end overloads ---
+    async def patch(self,body: list[NodeRestraintUpdate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPatchQueryParameters]] = None, **kwargs) -> Optional[NodeRestraintBulkResult]:
         """
         Partially updates multiple restraints in a single request. Each item must includeits parent `node` Id. Per-item 404 is reported as a bulk error if no row existsfor the supplied node. Only provided fields are changed; omitted fields keep theircurrent value.
         param body: The request body
@@ -85,7 +107,18 @@ class BulkRequestBuilder(BaseRequestBuilder):
 
         return await self.request_adapter.send_async(request_info, NodeRestraintBulkResult, error_mapping)
     
-    async def post(self,body: list[NodeRestraintCreate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPostQueryParameters]] = None) -> Optional[NodeRestraintBulkResult]:
+    # --- @overload added by regen_python_inits.py ---
+    @overload
+    async def post(
+        self,
+        body: list[NodeRestraintCreate],
+        *,
+        continue_on_error: Optional[bool] = None,
+    ) -> Optional[NodeRestraintBulkResult]: ...
+    @overload
+    async def post(self, body: list[NodeRestraintCreate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPostQueryParameters]] = None) -> Optional[NodeRestraintBulkResult]: ...
+    # --- end overloads ---
+    async def post(self,body: list[NodeRestraintCreate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPostQueryParameters]] = None, **kwargs) -> Optional[NodeRestraintBulkResult]:
         """
         Creates multiple restraint rows in a single request. Each item must include itsparent `node` Id. Per-item 409 is reported as a bulk error if a restraintalready exists for the supplied node. Variable-stiffness tables can be suppliedinline on each item.
         param body: The request body

--- a/sdks/python/client/space_gass_api/generated/job/structure/nodes/bulk/bulk_request_builder.py
+++ b/sdks/python/client/space_gass_api/generated/job/structure/nodes/bulk/bulk_request_builder.py
@@ -10,7 +10,7 @@ from kiota_abstractions.request_adapter import RequestAdapter
 from kiota_abstractions.request_information import RequestInformation
 from kiota_abstractions.request_option import RequestOption
 from kiota_abstractions.serialization import Parsable, ParsableFactory
-from typing import Any, Optional, TYPE_CHECKING, Union
+from typing import Any, Optional, TYPE_CHECKING, Union, overload
 from warnings import warn
 
 if TYPE_CHECKING:
@@ -33,7 +33,18 @@ class BulkRequestBuilder(BaseRequestBuilder):
         """
         super().__init__(request_adapter, "{+baseurl}/job/structure/nodes/bulk{?continueOnError*}", path_parameters)
     
-    async def delete(self,body: list[int], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderDeleteQueryParameters]] = None) -> Optional[BulkDeletedBulkResult]:
+    # --- @overload added by regen_python_inits.py ---
+    @overload
+    async def delete(
+        self,
+        body: list[int],
+        *,
+        continue_on_error: Optional[bool] = None,
+    ) -> Optional[BulkDeletedBulkResult]: ...
+    @overload
+    async def delete(self, body: list[int], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderDeleteQueryParameters]] = None) -> Optional[BulkDeletedBulkResult]: ...
+    # --- end overloads ---
+    async def delete(self,body: list[int], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderDeleteQueryParameters]] = None, **kwargs) -> Optional[BulkDeletedBulkResult]:
         """
         Deletes multiple entities by Id. The body is a JSON array of integer Ids(e.g. `[1, 5, 10]`) — consistent with every other bulk-delete endpointin the API (see CLAUDE.md "Query Parameter Conventions").            For cascading entities (Nodes, Members, Plates), `continueOnError` governs only theper-Id existence pre-check: a missing Id is reported and, when `false`, aborts thebatch. The cascade itself is planned and executed as a single unit — if cleanup failsmid-execution the entire batch is rolled back (affected datasheets are reloaded), so nopartial cascade is persisted.
         param body: The request body
@@ -59,7 +70,18 @@ class BulkRequestBuilder(BaseRequestBuilder):
 
         return await self.request_adapter.send_async(request_info, BulkDeletedBulkResult, error_mapping)
     
-    async def patch(self,body: list[NodeUpdate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPatchQueryParameters]] = None) -> Optional[NodeBulkResult]:
+    # --- @overload added by regen_python_inits.py ---
+    @overload
+    async def patch(
+        self,
+        body: list[NodeUpdate],
+        *,
+        continue_on_error: Optional[bool] = None,
+    ) -> Optional[NodeBulkResult]: ...
+    @overload
+    async def patch(self, body: list[NodeUpdate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPatchQueryParameters]] = None) -> Optional[NodeBulkResult]: ...
+    # --- end overloads ---
+    async def patch(self,body: list[NodeUpdate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPatchQueryParameters]] = None, **kwargs) -> Optional[NodeBulkResult]:
         """
         Updates multiple items in a bulk operation.Each item must include its Id in the request body.If a validator is registered, all items are validated upfront before any are updated.
         param body: The request body
@@ -85,7 +107,18 @@ class BulkRequestBuilder(BaseRequestBuilder):
 
         return await self.request_adapter.send_async(request_info, NodeBulkResult, error_mapping)
     
-    async def post(self,body: list[NodeCreate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPostQueryParameters]] = None) -> Optional[NodeBulkResult]:
+    # --- @overload added by regen_python_inits.py ---
+    @overload
+    async def post(
+        self,
+        body: list[NodeCreate],
+        *,
+        continue_on_error: Optional[bool] = None,
+    ) -> Optional[NodeBulkResult]: ...
+    @overload
+    async def post(self, body: list[NodeCreate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPostQueryParameters]] = None) -> Optional[NodeBulkResult]: ...
+    # --- end overloads ---
+    async def post(self,body: list[NodeCreate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPostQueryParameters]] = None, **kwargs) -> Optional[NodeBulkResult]:
         """
         Creates multiple items in a bulk operation.If a validator is registered, all items are validated upfront before any are created.
         param body: The request body

--- a/sdks/python/client/space_gass_api/generated/job/structure/plate_cuts/bulk/bulk_request_builder.py
+++ b/sdks/python/client/space_gass_api/generated/job/structure/plate_cuts/bulk/bulk_request_builder.py
@@ -10,7 +10,7 @@ from kiota_abstractions.request_adapter import RequestAdapter
 from kiota_abstractions.request_information import RequestInformation
 from kiota_abstractions.request_option import RequestOption
 from kiota_abstractions.serialization import Parsable, ParsableFactory
-from typing import Any, Optional, TYPE_CHECKING, Union
+from typing import Any, Optional, TYPE_CHECKING, Union, overload
 from warnings import warn
 
 if TYPE_CHECKING:
@@ -33,7 +33,18 @@ class BulkRequestBuilder(BaseRequestBuilder):
         """
         super().__init__(request_adapter, "{+baseurl}/job/structure/plate-cuts/bulk{?continueOnError*}", path_parameters)
     
-    async def delete(self,body: list[int], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderDeleteQueryParameters]] = None) -> Optional[BulkDeletedBulkResult]:
+    # --- @overload added by regen_python_inits.py ---
+    @overload
+    async def delete(
+        self,
+        body: list[int],
+        *,
+        continue_on_error: Optional[bool] = None,
+    ) -> Optional[BulkDeletedBulkResult]: ...
+    @overload
+    async def delete(self, body: list[int], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderDeleteQueryParameters]] = None) -> Optional[BulkDeletedBulkResult]: ...
+    # --- end overloads ---
+    async def delete(self,body: list[int], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderDeleteQueryParameters]] = None, **kwargs) -> Optional[BulkDeletedBulkResult]:
         """
         Deletes multiple entities by Id. The body is a JSON array of integer Ids(e.g. `[1, 5, 10]`) — consistent with every other bulk-delete endpointin the API (see CLAUDE.md "Query Parameter Conventions").            For cascading entities (Nodes, Members, Plates), `continueOnError` governs only theper-Id existence pre-check: a missing Id is reported and, when `false`, aborts thebatch. The cascade itself is planned and executed as a single unit — if cleanup failsmid-execution the entire batch is rolled back (affected datasheets are reloaded), so nopartial cascade is persisted.
         param body: The request body
@@ -59,7 +70,18 @@ class BulkRequestBuilder(BaseRequestBuilder):
 
         return await self.request_adapter.send_async(request_info, BulkDeletedBulkResult, error_mapping)
     
-    async def patch(self,body: list[PlateCutUpdate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPatchQueryParameters]] = None) -> Optional[PlateCutBulkResult]:
+    # --- @overload added by regen_python_inits.py ---
+    @overload
+    async def patch(
+        self,
+        body: list[PlateCutUpdate],
+        *,
+        continue_on_error: Optional[bool] = None,
+    ) -> Optional[PlateCutBulkResult]: ...
+    @overload
+    async def patch(self, body: list[PlateCutUpdate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPatchQueryParameters]] = None) -> Optional[PlateCutBulkResult]: ...
+    # --- end overloads ---
+    async def patch(self,body: list[PlateCutUpdate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPatchQueryParameters]] = None, **kwargs) -> Optional[PlateCutBulkResult]:
         """
         Updates multiple items in a bulk operation.Each item must include its Id in the request body.If a validator is registered, all items are validated upfront before any are updated.
         param body: The request body
@@ -85,7 +107,18 @@ class BulkRequestBuilder(BaseRequestBuilder):
 
         return await self.request_adapter.send_async(request_info, PlateCutBulkResult, error_mapping)
     
-    async def post(self,body: list[PlateCutCreate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPostQueryParameters]] = None) -> Optional[PlateCutBulkResult]:
+    # --- @overload added by regen_python_inits.py ---
+    @overload
+    async def post(
+        self,
+        body: list[PlateCutCreate],
+        *,
+        continue_on_error: Optional[bool] = None,
+    ) -> Optional[PlateCutBulkResult]: ...
+    @overload
+    async def post(self, body: list[PlateCutCreate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPostQueryParameters]] = None) -> Optional[PlateCutBulkResult]: ...
+    # --- end overloads ---
+    async def post(self,body: list[PlateCutCreate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPostQueryParameters]] = None, **kwargs) -> Optional[PlateCutBulkResult]:
         """
         Creates multiple items in a bulk operation.If a validator is registered, all items are validated upfront before any are created.
         param body: The request body

--- a/sdks/python/client/space_gass_api/generated/job/structure/plate_strips/bulk/bulk_request_builder.py
+++ b/sdks/python/client/space_gass_api/generated/job/structure/plate_strips/bulk/bulk_request_builder.py
@@ -10,7 +10,7 @@ from kiota_abstractions.request_adapter import RequestAdapter
 from kiota_abstractions.request_information import RequestInformation
 from kiota_abstractions.request_option import RequestOption
 from kiota_abstractions.serialization import Parsable, ParsableFactory
-from typing import Any, Optional, TYPE_CHECKING, Union
+from typing import Any, Optional, TYPE_CHECKING, Union, overload
 from warnings import warn
 
 if TYPE_CHECKING:
@@ -33,7 +33,18 @@ class BulkRequestBuilder(BaseRequestBuilder):
         """
         super().__init__(request_adapter, "{+baseurl}/job/structure/plate-strips/bulk{?continueOnError*}", path_parameters)
     
-    async def delete(self,body: list[int], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderDeleteQueryParameters]] = None) -> Optional[BulkDeletedBulkResult]:
+    # --- @overload added by regen_python_inits.py ---
+    @overload
+    async def delete(
+        self,
+        body: list[int],
+        *,
+        continue_on_error: Optional[bool] = None,
+    ) -> Optional[BulkDeletedBulkResult]: ...
+    @overload
+    async def delete(self, body: list[int], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderDeleteQueryParameters]] = None) -> Optional[BulkDeletedBulkResult]: ...
+    # --- end overloads ---
+    async def delete(self,body: list[int], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderDeleteQueryParameters]] = None, **kwargs) -> Optional[BulkDeletedBulkResult]:
         """
         Deletes multiple entities by Id. The body is a JSON array of integer Ids(e.g. `[1, 5, 10]`) — consistent with every other bulk-delete endpointin the API (see CLAUDE.md "Query Parameter Conventions").            For cascading entities (Nodes, Members, Plates), `continueOnError` governs only theper-Id existence pre-check: a missing Id is reported and, when `false`, aborts thebatch. The cascade itself is planned and executed as a single unit — if cleanup failsmid-execution the entire batch is rolled back (affected datasheets are reloaded), so nopartial cascade is persisted.
         param body: The request body
@@ -59,7 +70,18 @@ class BulkRequestBuilder(BaseRequestBuilder):
 
         return await self.request_adapter.send_async(request_info, BulkDeletedBulkResult, error_mapping)
     
-    async def patch(self,body: list[PlateStripUpdate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPatchQueryParameters]] = None) -> Optional[PlateStripBulkResult]:
+    # --- @overload added by regen_python_inits.py ---
+    @overload
+    async def patch(
+        self,
+        body: list[PlateStripUpdate],
+        *,
+        continue_on_error: Optional[bool] = None,
+    ) -> Optional[PlateStripBulkResult]: ...
+    @overload
+    async def patch(self, body: list[PlateStripUpdate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPatchQueryParameters]] = None) -> Optional[PlateStripBulkResult]: ...
+    # --- end overloads ---
+    async def patch(self,body: list[PlateStripUpdate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPatchQueryParameters]] = None, **kwargs) -> Optional[PlateStripBulkResult]:
         """
         Updates multiple items in a bulk operation.Each item must include its Id in the request body.If a validator is registered, all items are validated upfront before any are updated.
         param body: The request body
@@ -85,7 +107,18 @@ class BulkRequestBuilder(BaseRequestBuilder):
 
         return await self.request_adapter.send_async(request_info, PlateStripBulkResult, error_mapping)
     
-    async def post(self,body: list[PlateStripCreate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPostQueryParameters]] = None) -> Optional[PlateStripBulkResult]:
+    # --- @overload added by regen_python_inits.py ---
+    @overload
+    async def post(
+        self,
+        body: list[PlateStripCreate],
+        *,
+        continue_on_error: Optional[bool] = None,
+    ) -> Optional[PlateStripBulkResult]: ...
+    @overload
+    async def post(self, body: list[PlateStripCreate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPostQueryParameters]] = None) -> Optional[PlateStripBulkResult]: ...
+    # --- end overloads ---
+    async def post(self,body: list[PlateStripCreate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPostQueryParameters]] = None, **kwargs) -> Optional[PlateStripBulkResult]:
         """
         Creates multiple items in a bulk operation.If a validator is registered, all items are validated upfront before any are created.
         param body: The request body

--- a/sdks/python/client/space_gass_api/generated/job/structure/plates/bulk/bulk_request_builder.py
+++ b/sdks/python/client/space_gass_api/generated/job/structure/plates/bulk/bulk_request_builder.py
@@ -10,7 +10,7 @@ from kiota_abstractions.request_adapter import RequestAdapter
 from kiota_abstractions.request_information import RequestInformation
 from kiota_abstractions.request_option import RequestOption
 from kiota_abstractions.serialization import Parsable, ParsableFactory
-from typing import Any, Optional, TYPE_CHECKING, Union
+from typing import Any, Optional, TYPE_CHECKING, Union, overload
 from warnings import warn
 
 if TYPE_CHECKING:
@@ -33,7 +33,18 @@ class BulkRequestBuilder(BaseRequestBuilder):
         """
         super().__init__(request_adapter, "{+baseurl}/job/structure/plates/bulk{?continueOnError*}", path_parameters)
     
-    async def delete(self,body: list[int], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderDeleteQueryParameters]] = None) -> Optional[BulkDeletedBulkResult]:
+    # --- @overload added by regen_python_inits.py ---
+    @overload
+    async def delete(
+        self,
+        body: list[int],
+        *,
+        continue_on_error: Optional[bool] = None,
+    ) -> Optional[BulkDeletedBulkResult]: ...
+    @overload
+    async def delete(self, body: list[int], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderDeleteQueryParameters]] = None) -> Optional[BulkDeletedBulkResult]: ...
+    # --- end overloads ---
+    async def delete(self,body: list[int], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderDeleteQueryParameters]] = None, **kwargs) -> Optional[BulkDeletedBulkResult]:
         """
         Deletes multiple entities by Id. The body is a JSON array of integer Ids(e.g. `[1, 5, 10]`) — consistent with every other bulk-delete endpointin the API (see CLAUDE.md "Query Parameter Conventions").            For cascading entities (Nodes, Members, Plates), `continueOnError` governs only theper-Id existence pre-check: a missing Id is reported and, when `false`, aborts thebatch. The cascade itself is planned and executed as a single unit — if cleanup failsmid-execution the entire batch is rolled back (affected datasheets are reloaded), so nopartial cascade is persisted.
         param body: The request body
@@ -59,7 +70,18 @@ class BulkRequestBuilder(BaseRequestBuilder):
 
         return await self.request_adapter.send_async(request_info, BulkDeletedBulkResult, error_mapping)
     
-    async def patch(self,body: list[PlateUpdate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPatchQueryParameters]] = None) -> Optional[PlateBulkResult]:
+    # --- @overload added by regen_python_inits.py ---
+    @overload
+    async def patch(
+        self,
+        body: list[PlateUpdate],
+        *,
+        continue_on_error: Optional[bool] = None,
+    ) -> Optional[PlateBulkResult]: ...
+    @overload
+    async def patch(self, body: list[PlateUpdate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPatchQueryParameters]] = None) -> Optional[PlateBulkResult]: ...
+    # --- end overloads ---
+    async def patch(self,body: list[PlateUpdate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPatchQueryParameters]] = None, **kwargs) -> Optional[PlateBulkResult]:
         """
         Updates multiple items in a bulk operation.Each item must include its Id in the request body.If a validator is registered, all items are validated upfront before any are updated.
         param body: The request body
@@ -85,7 +107,18 @@ class BulkRequestBuilder(BaseRequestBuilder):
 
         return await self.request_adapter.send_async(request_info, PlateBulkResult, error_mapping)
     
-    async def post(self,body: list[PlateCreate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPostQueryParameters]] = None) -> Optional[PlateBulkResult]:
+    # --- @overload added by regen_python_inits.py ---
+    @overload
+    async def post(
+        self,
+        body: list[PlateCreate],
+        *,
+        continue_on_error: Optional[bool] = None,
+    ) -> Optional[PlateBulkResult]: ...
+    @overload
+    async def post(self, body: list[PlateCreate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPostQueryParameters]] = None) -> Optional[PlateBulkResult]: ...
+    # --- end overloads ---
+    async def post(self,body: list[PlateCreate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPostQueryParameters]] = None, **kwargs) -> Optional[PlateBulkResult]:
         """
         Creates multiple items in a bulk operation.If a validator is registered, all items are validated upfront before any are created.
         param body: The request body

--- a/sdks/python/client/space_gass_api/generated/job/structure/sections/bulk/bulk_request_builder.py
+++ b/sdks/python/client/space_gass_api/generated/job/structure/sections/bulk/bulk_request_builder.py
@@ -10,7 +10,7 @@ from kiota_abstractions.request_adapter import RequestAdapter
 from kiota_abstractions.request_information import RequestInformation
 from kiota_abstractions.request_option import RequestOption
 from kiota_abstractions.serialization import Parsable, ParsableFactory
-from typing import Any, Optional, TYPE_CHECKING, Union
+from typing import Any, Optional, TYPE_CHECKING, Union, overload
 from warnings import warn
 
 if TYPE_CHECKING:
@@ -33,7 +33,18 @@ class BulkRequestBuilder(BaseRequestBuilder):
         """
         super().__init__(request_adapter, "{+baseurl}/job/structure/sections/bulk{?continueOnError*}", path_parameters)
     
-    async def delete(self,body: list[int], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderDeleteQueryParameters]] = None) -> Optional[BulkDeletedBulkResult]:
+    # --- @overload added by regen_python_inits.py ---
+    @overload
+    async def delete(
+        self,
+        body: list[int],
+        *,
+        continue_on_error: Optional[bool] = None,
+    ) -> Optional[BulkDeletedBulkResult]: ...
+    @overload
+    async def delete(self, body: list[int], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderDeleteQueryParameters]] = None) -> Optional[BulkDeletedBulkResult]: ...
+    # --- end overloads ---
+    async def delete(self,body: list[int], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderDeleteQueryParameters]] = None, **kwargs) -> Optional[BulkDeletedBulkResult]:
         """
         Deletes multiple entities by Id. The body is a JSON array of integer Ids(e.g. `[1, 5, 10]`) — consistent with every other bulk-delete endpointin the API (see CLAUDE.md "Query Parameter Conventions").            For cascading entities (Nodes, Members, Plates), `continueOnError` governs only theper-Id existence pre-check: a missing Id is reported and, when `false`, aborts thebatch. The cascade itself is planned and executed as a single unit — if cleanup failsmid-execution the entire batch is rolled back (affected datasheets are reloaded), so nopartial cascade is persisted.
         param body: The request body
@@ -59,7 +70,18 @@ class BulkRequestBuilder(BaseRequestBuilder):
 
         return await self.request_adapter.send_async(request_info, BulkDeletedBulkResult, error_mapping)
     
-    async def patch(self,body: list[SectionUpdate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPatchQueryParameters]] = None) -> Optional[SectionBulkResult]:
+    # --- @overload added by regen_python_inits.py ---
+    @overload
+    async def patch(
+        self,
+        body: list[SectionUpdate],
+        *,
+        continue_on_error: Optional[bool] = None,
+    ) -> Optional[SectionBulkResult]: ...
+    @overload
+    async def patch(self, body: list[SectionUpdate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPatchQueryParameters]] = None) -> Optional[SectionBulkResult]: ...
+    # --- end overloads ---
+    async def patch(self,body: list[SectionUpdate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPatchQueryParameters]] = None, **kwargs) -> Optional[SectionBulkResult]:
         """
         Updates multiple items in a bulk operation.Each item must include its Id in the request body.If a validator is registered, all items are validated upfront before any are updated.
         param body: The request body
@@ -85,7 +107,18 @@ class BulkRequestBuilder(BaseRequestBuilder):
 
         return await self.request_adapter.send_async(request_info, SectionBulkResult, error_mapping)
     
-    async def post(self,body: list[SectionUserCreate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPostQueryParameters]] = None) -> Optional[SectionBulkResult]:
+    # --- @overload added by regen_python_inits.py ---
+    @overload
+    async def post(
+        self,
+        body: list[SectionUserCreate],
+        *,
+        continue_on_error: Optional[bool] = None,
+    ) -> Optional[SectionBulkResult]: ...
+    @overload
+    async def post(self, body: list[SectionUserCreate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPostQueryParameters]] = None) -> Optional[SectionBulkResult]: ...
+    # --- end overloads ---
+    async def post(self,body: list[SectionUserCreate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPostQueryParameters]] = None, **kwargs) -> Optional[SectionBulkResult]:
         """
         Creates multiple items in a bulk operation.If a validator is registered, all items are validated upfront before any are created.
         param body: The request body

--- a/sdks/python/client/space_gass_api/generated/job/structure/sections/library/bulk/bulk_request_builder.py
+++ b/sdks/python/client/space_gass_api/generated/job/structure/sections/library/bulk/bulk_request_builder.py
@@ -10,7 +10,7 @@ from kiota_abstractions.request_adapter import RequestAdapter
 from kiota_abstractions.request_information import RequestInformation
 from kiota_abstractions.request_option import RequestOption
 from kiota_abstractions.serialization import Parsable, ParsableFactory
-from typing import Any, Optional, TYPE_CHECKING, Union
+from typing import Any, Optional, TYPE_CHECKING, Union, overload
 from warnings import warn
 
 if TYPE_CHECKING:
@@ -31,7 +31,18 @@ class BulkRequestBuilder(BaseRequestBuilder):
         """
         super().__init__(request_adapter, "{+baseurl}/job/structure/sections/library/bulk{?continueOnError*}", path_parameters)
     
-    async def post(self,body: list[SectionLibraryCreate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPostQueryParameters]] = None) -> Optional[SectionBulkResult]:
+    # --- @overload added by regen_python_inits.py ---
+    @overload
+    async def post(
+        self,
+        body: list[SectionLibraryCreate],
+        *,
+        continue_on_error: Optional[bool] = None,
+    ) -> Optional[SectionBulkResult]: ...
+    @overload
+    async def post(self, body: list[SectionLibraryCreate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPostQueryParameters]] = None) -> Optional[SectionBulkResult]: ...
+    # --- end overloads ---
+    async def post(self,body: list[SectionLibraryCreate], request_configuration: Optional[RequestConfiguration[BulkRequestBuilderPostQueryParameters]] = None, **kwargs) -> Optional[SectionBulkResult]:
         """
         Creates multiple library-sourced sections in a single request. Each section isresolved from the SPACE GASS section library by (name, library).
         param body: The request body

--- a/sdks/python/client/space_gass_api/space_gass_api_client.py
+++ b/sdks/python/client/space_gass_api/space_gass_api_client.py
@@ -2,7 +2,8 @@
 Hand-maintained client for the SPACE GASS API.
 
 Extends the Kiota-generated ``BaseSpaceGassApiClient`` with a
-``create_client()`` factory and the ``.get(**kwargs)`` enhancement.
+``create_client()`` factory and the keyword-query-parameter enhancement
+on ``get``/``post``/``patch``/``put``/``delete``.
 
 Lives inside the ``space_gass_api`` package but outside the
 ``generated/`` folder, so Kiota's ``--clean-output`` never touches it.
@@ -20,6 +21,10 @@ Usage:
 
     reactions = await client.job.query.analysis.static.node_reactions.get(
         cases="1,3-7", nodes="10-12")
+
+    # POST/PATCH/DELETE with keyword query parameters
+    result = await client.job.structure.nodes.bulk.post(
+        bodies, continue_on_error=True)
 """
 
 from __future__ import annotations
@@ -90,10 +95,11 @@ class SpaceGassApiClient(BaseSpaceGassApiClient):
         return SpaceGassApiClient(adapter)
 
 
-def _enhance_get_methods():
+def _enhance_request_methods():
     """Patch ``BaseRequestBuilder.__init_subclass__`` so every Kiota builder
-    whose class body contains a ``{ClassName}GetQueryParameters`` dataclass
-    gets its ``.get()`` wrapped to accept keyword arguments directly.
+    whose class body contains a ``{ClassName}{Verb}QueryParameters`` dataclass
+    gets that verb method (``get``/``post``/``patch``/``put``/``delete``)
+    wrapped to accept keyword query parameters directly.
 
     Must be called **once**, before any builder module is imported.  The
     auto-generated ``space_gass_api/__init__.py`` takes care of this.
@@ -101,35 +107,61 @@ def _enhance_get_methods():
     from kiota_abstractions.base_request_builder import BaseRequestBuilder
     from kiota_abstractions.base_request_configuration import RequestConfiguration
     import functools
+    import inspect
 
-    if getattr(BaseRequestBuilder, "_get_enhanced", False):
+    if getattr(BaseRequestBuilder, "_request_methods_enhanced", False):
         return
 
-    def _init_subclass(cls, **kwargs):
-        qp_name = f"{cls.__name__}GetQueryParameters"
-        qp_class = cls.__dict__.get(qp_name)
+    def _wrap(original, qp_class, label):
+        # Kiota emits `post(self, body, request_configuration=None)` when the
+        # endpoint has a request body and drops `body` when it doesn't, so the
+        # wrapper has to mirror whichever shape it is given.
+        has_body = "body" in inspect.signature(original).parameters
 
-        if qp_class is not None and "get" in cls.__dict__:
-            original_get = cls.__dict__["get"]
+        def _config_from(params, request_configuration):
+            if not params:
+                return request_configuration
+            if request_configuration is not None:
+                raise TypeError(
+                    f"Cannot pass both request_configuration and "
+                    f"keyword query parameters to {label}."
+                )
+            return RequestConfiguration(query_parameters=qp_class(**params))
 
-            @functools.wraps(original_get)
-            async def enhanced_get(self, request_configuration=None, **params):
-                if params:
-                    if request_configuration is not None:
-                        raise TypeError(
-                            f"Cannot pass both request_configuration and "
-                            f"keyword query parameters to "
-                            f"{type(self).__name__}.get()."
-                        )
-                    qp = qp_class(**params)
-                    request_configuration = RequestConfiguration(
-                        query_parameters=qp
-                    )
-                return await original_get(
-                    self, request_configuration=request_configuration
+        if has_body:
+
+            @functools.wraps(original)
+            async def enhanced(self, body, request_configuration=None, **params):
+                return await original(
+                    self,
+                    body,
+                    request_configuration=_config_from(params, request_configuration),
                 )
 
-            cls.get = enhanced_get
+        else:
+
+            @functools.wraps(original)
+            async def enhanced(self, request_configuration=None, **params):
+                return await original(
+                    self,
+                    request_configuration=_config_from(params, request_configuration),
+                )
+
+        return enhanced
+
+    def _init_subclass(cls, **kwargs):
+        for verb in ("get", "post", "patch", "put", "delete"):
+            qp_class = cls.__dict__.get(
+                f"{cls.__name__}{verb.capitalize()}QueryParameters"
+            )
+            original = cls.__dict__.get(verb)
+            if qp_class is None or original is None:
+                continue
+            setattr(
+                cls,
+                verb,
+                _wrap(original, qp_class, f"{cls.__name__}.{verb}()"),
+            )
 
     BaseRequestBuilder.__init_subclass__ = classmethod(_init_subclass)
-    BaseRequestBuilder._get_enhanced = True
+    BaseRequestBuilder._request_methods_enhanced = True

--- a/tools/regen_python_inits.py
+++ b/tools/regen_python_inits.py
@@ -9,7 +9,8 @@ fail to resolve.
 This script does four things after Kiota regeneration:
 
   1. Writes ``space_gass_api/__init__.py``
-       - calls ``_enhance_get_methods()`` to enable ``.get(**kwargs)``
+       - calls ``_enhance_request_methods()`` to enable keyword query
+         parameters on ``get``/``post``/``patch``/``put``/``delete``
        - imports and re-exports ``SpaceGassApiClient``
 
   2. Writes ``space_gass_api/__init__.pyi``
@@ -20,9 +21,10 @@ This script does four things after Kiota regeneration:
          so callers can write ``models.NodeCreate`` etc.
 
   4. Injects ``@overload`` stubs into every ``*_request_builder.py``
-       whose class body contains a ``GetQueryParameters`` dataclass,
+       whose class body contains a ``{Verb}QueryParameters`` dataclass,
        so Pyright / Pylance shows the keyword arguments in IntelliSense
-       when users call ``.get(node_type=..., limit=...)``.
+       when users call ``.get(node_type=..., limit=...)`` or
+       ``.bulk.post(bodies, continue_on_error=True)``.
 
 Idempotent — rerunning produces byte-identical output.
 
@@ -60,9 +62,10 @@ client:
 - ``SpaceGassApiClient`` extends the generated ``BaseApiClient``
   with the ``create_client()`` factory method.
 
-- ``.get(**kwargs)`` is auto-enhanced on every builder that has GET
-  query parameters, so callers can pass filters as keyword arguments
-  directly instead of constructing ``RequestConfiguration`` objects.
+- Request methods (``get``/``post``/``patch``/``put``/``delete``) are
+  auto-enhanced on every builder that defines query parameters for that
+  verb, so callers can pass them as keyword arguments directly instead
+  of constructing ``RequestConfiguration`` objects.
 
 Usage:
 
@@ -73,11 +76,13 @@ Usage:
     node = await client.job.structure.nodes.post(models.NodeCreate(x=0, y=0, z=0))
     restrained = await client.job.structure.nodes.get(
         node_type=models.NodeTypeFilter.Restrained)
+    created = await client.job.structure.nodes.bulk.post(
+        bodies, continue_on_error=True)
 """
 
-from .space_gass_api_client import _enhance_get_methods
+from .space_gass_api_client import _enhance_request_methods
 
-_enhance_get_methods()
+_enhance_request_methods()
 
 from .space_gass_api_client import SpaceGassApiClient
 from .upload_requests import ImportTxtRequest, NewFromTemplateRequest
@@ -132,11 +137,18 @@ OVERLOAD_BANNER = "    # --- @overload added by regen_python_inits.py ---"
 OVERLOAD_FENCE = "    # --- end overloads ---"
 
 
-def _parse_builder(source: str) -> tuple[str, list[tuple[str, str]], str] | None:
+VERBS = ("get", "post", "patch", "put", "delete")
+
+
+def _parse_builder(
+    source: str,
+) -> list[tuple[str, str, list[tuple[str, str]], str | None, str]]:
     """Extract overload info from a builder module.
 
-    Returns ``(qp_class_name, [(field, type_str), ...], return_type_str)``
-    or ``None`` if the builder has no ``GetQueryParameters``.
+    Returns one ``(verb, qp_class_name, [(field, type_str), ...],
+    body_type_str | None, return_type_str)`` entry per verb method whose
+    class body contains a matching ``{Builder}{Verb}QueryParameters``
+    dataclass. ``body_type_str`` is ``None`` for body-less methods.
     """
     tree = ast.parse(source)
 
@@ -146,35 +158,44 @@ def _parse_builder(source: str) -> tuple[str, list[tuple[str, str]], str] | None
         None,
     )
     if builder is None:
-        return None
+        return []
 
-    qp_name = f"{builder.name}GetQueryParameters"
-    qp_cls = next(
-        (n for n in ast.iter_child_nodes(builder)
-         if isinstance(n, ast.ClassDef) and n.name == qp_name),
-        None,
-    )
-    if qp_cls is None:
-        return None
+    specs: list[tuple[str, str, list[tuple[str, str]], str | None, str]] = []
+    for verb in VERBS:
+        qp_name = f"{builder.name}{verb.capitalize()}QueryParameters"
+        qp_cls = next(
+            (n for n in ast.iter_child_nodes(builder)
+             if isinstance(n, ast.ClassDef) and n.name == qp_name),
+            None,
+        )
+        if qp_cls is None:
+            continue
 
-    fields = [
-        (n.target.id, ast.unparse(n.annotation))
-        for n in ast.iter_child_nodes(qp_cls)
-        if isinstance(n, ast.AnnAssign) and isinstance(n.target, ast.Name)
-    ]
-    if not fields:
-        return None
+        fields = [
+            (n.target.id, ast.unparse(n.annotation))
+            for n in ast.iter_child_nodes(qp_cls)
+            if isinstance(n, ast.AnnAssign) and isinstance(n.target, ast.Name)
+        ]
+        if not fields:
+            continue
 
-    get_m = next(
-        (n for n in ast.iter_child_nodes(builder)
-         if isinstance(n, (ast.AsyncFunctionDef, ast.FunctionDef))
-         and n.name == "get"),
-        None,
-    )
-    if get_m is None or get_m.returns is None:
-        return None
+        method = next(
+            (n for n in ast.iter_child_nodes(builder)
+             if isinstance(n, (ast.AsyncFunctionDef, ast.FunctionDef))
+             and n.name == verb),
+            None,
+        )
+        if method is None or method.returns is None:
+            continue
 
-    return qp_name, fields, ast.unparse(get_m.returns)
+        body_arg = next((a for a in method.args.args if a.arg == "body"), None)
+        if body_arg is not None and body_arg.annotation is None:
+            continue
+        body_type = ast.unparse(body_arg.annotation) if body_arg is not None else None
+
+        specs.append((verb, qp_name, fields, body_type, ast.unparse(method.returns)))
+
+    return specs
 
 
 def _strip_overloads(source: str) -> str:
@@ -193,11 +214,13 @@ def _strip_overloads(source: str) -> str:
 
 def _inject_overloads(
     source: str,
+    verb: str,
     qp_name: str,
     fields: list[tuple[str, str]],
+    body_type: str | None,
     ret_type: str,
 ) -> str:
-    """Inject ``@overload`` stubs and ``**kwargs`` into a builder source."""
+    """Inject ``@overload`` stubs and ``**kwargs`` for one verb method."""
     lines = source.splitlines(keepends=True)
 
     # Ensure 'overload' is in the typing imports
@@ -206,46 +229,50 @@ def _inject_overloads(
             lines[i] = line.rstrip("\n").rstrip() + ", overload\n"
             break
 
-    # Find the `async def get(self,` line
-    get_idx = next(
+    # Find the `async def {verb}(self` line
+    m_idx = next(
         (i for i, ln in enumerate(lines)
-         if ln.strip().startswith("async def get(self")),
+         if ln.strip().startswith(f"async def {verb}(self")),
         None,
     )
-    if get_idx is None:
+    if m_idx is None:
         return source
 
     # Add **kwargs to the implementation signature
-    lines[get_idx] = lines[get_idx].replace(") ->", ", **kwargs) ->")
+    lines[m_idx] = lines[m_idx].replace(") ->", ", **kwargs) ->")
 
     # Build the overload block
     ind = "    "
     block: list[str] = []
     block.append(f"{OVERLOAD_BANNER}\n")
     block.append(f"{ind}@overload\n")
-    block.append(f"{ind}async def get(\n")
+    block.append(f"{ind}async def {verb}(\n")
     block.append(f"{ind}    self,\n")
+    if body_type is not None:
+        block.append(f"{ind}    body: {body_type},\n")
     block.append(f"{ind}    *,\n")
     for fname, ftype in fields:
         block.append(f"{ind}    {fname}: {ftype} = None,\n")
     block.append(f"{ind}) -> {ret_type}: ...\n")
     block.append(f"{ind}@overload\n")
     rc = f"Optional[RequestConfiguration[{qp_name}]]"
+    body_param = f"body: {body_type}, " if body_type is not None else ""
     block.append(
-        f"{ind}async def get(self, request_configuration: "
+        f"{ind}async def {verb}(self, {body_param}request_configuration: "
         f"{rc} = None) -> {ret_type}: ...\n"
     )
     block.append(f"{OVERLOAD_FENCE}\n")
 
-    # Insert block right before the get method
+    # Insert block right before the verb method
     for j, bl in enumerate(block):
-        lines.insert(get_idx + j, bl)
+        lines.insert(m_idx + j, bl)
 
     return "".join(lines)
 
 
-def enhance_builder_get_methods() -> int:
-    """Inject ``@overload`` stubs into every builder with GetQueryParameters.
+def enhance_builder_methods() -> int:
+    """Inject ``@overload`` stubs into every builder whose verb methods
+    have matching ``QueryParameters`` dataclasses.
 
     This gives Pyright / Pylance the typed kwargs signature so
     IntelliSense shows the available query parameters.
@@ -257,14 +284,17 @@ def enhance_builder_get_methods() -> int:
         source = path.read_text(encoding="utf-8")
         clean = _strip_overloads(source)
 
-        info = _parse_builder(clean)
-        if info is None:
+        specs = _parse_builder(clean)
+        if not specs:
             if clean != source:
                 path.write_text(clean, encoding="utf-8")
             continue
 
-        qp_name, fields, ret_type = info
-        modified = _inject_overloads(clean, qp_name, fields, ret_type)
+        modified = clean
+        for verb, qp_name, fields, body_type, ret_type in specs:
+            modified = _inject_overloads(
+                modified, verb, qp_name, fields, body_type, ret_type
+            )
 
         if modified != source:
             path.write_text(modified, encoding="utf-8")
@@ -294,7 +324,7 @@ def main() -> None:
     PKG_INIT_PYI.write_text(PKG_INIT_STUB, encoding="utf-8")
     MODELS_INIT.write_text(render_models_init(entries), encoding="utf-8")
 
-    enhanced = enhance_builder_get_methods()
+    enhanced = enhance_builder_methods()
 
     print(f"wrote {PKG_INIT.relative_to(REPO_ROOT)}")
     print(f"wrote {PKG_INIT_PYI.relative_to(REPO_ROOT)}")


### PR DESCRIPTION
## Summary

Started from a client bug report: the Error Handling guide's Python snippet imported `ErrorResponse` from `space_gass_api.models.error_response`, which doesn't exist (`space_gass_api.models` is a re-export shim — submodule imports raise `ModuleNotFoundError`). A sweep found the same class of bug on two more pages, and fixing the last one properly grew into a small SDK enhancement.

### Commit 1 — docs: fix broken Python imports
- `error-handling.mdx`: `from space_gass_api.models import ErrorResponse` (client-reported)
- `file-handling.mdx`: same fix for `OpenJobRequest` / `SaveJobRequest`, and the file-status snippet now uses the supported kwargs form `client.file.status.get(file_path=...)` instead of importing a builder from another nonexistent path
- Verified against the package: every corrected import resolves, every old one fails

### Commit 2 — Python SDK: kwargs query params on all verbs
The bulk-operations guide needed `RequestConfiguration` + a deep `generated/` builder import just to pass `continueOnError=true`. Instead of documenting that boilerplate, the kwargs enhancement (previously GET-only) now covers `post`/`patch`/`put`/`delete` wherever the builder defines query parameters:

```python
result = await client.job.structure.nodes.bulk.post(bodies, continue_on_error=True)
```

- `_enhance_request_methods()` (renamed from `_enhance_get_methods()`) wraps each verb with a matching `{Verb}QueryParameters` dataclass, detecting body vs body-less signatures at class-creation time
- `tools/regen_python_inits.py` now injects body-aware `@overload` stubs for all verbs (32 builders updated; rerun is byte-identical)
- AGENTS.md / CLAUDE.md updated; C# needs no change (`PostAsync(body, config => ...)` is already idiomatic)

## Verification

- Offline end-to-end suite through `httpx.MockTransport` (real adapter, serialization, URL templating): 14/14 — kwargs produce correct wire URLs/methods/bodies on all verbs; plain calls, `request_configuration=`, and GET are unregressed; unknown kwargs and rc+kwargs raise `TypeError`
- pyright: kwargs overloads resolve with typed returns (`NodeBulkResult | None`, `Job | None`); a bogus kwarg is flagged as a type error
- `python -m compileall` over the whole package passes; regen script idempotency confirmed via identical diff hashes

Note: the SDK behavior addition is worth a minor version bump when it next ships to PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
