### PR TITLE
Add C# and Python client test suites, CI workflow, and README badges

### DIFF
--- a/.github/workflows/test-clients.yml
+++ b/.github/workflows/test-clients.yml
@@ -1,0 +1,45 @@
+name: Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  csharp:
+    name: C# client
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Run tests
+        run: dotnet test sdks/csharp/client/SpaceGassApi.sln --nologo
+
+  python:
+    name: Python client
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install client with dev dependencies
+        working-directory: sdks/python/client
+        run: pip install -e ".[dev]"
+
+      - name: Run tests
+        working-directory: sdks/python/client
+        run: python -m pytest -q

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,8 @@ Cross-tool agent instructions (install, `CreateClient()`, base URL, async/analys
 
 ```
 sdks/csharp/client/
-├── SpaceGassApi.sln                     ← client solution (+ future tests)
+├── SpaceGassApi.sln                     ← client solution (SDK + tests)
+├── SpaceGassApi.Tests/                  ← xUnit tests; wire-level via in-process CapturingHandler (`dotnet test`)
 └── SpaceGassApi/
     ├── SpaceGassApi.csproj              ← hand-maintained (safe from Kiota regen)
     ├── SpaceGassApiClient.cs            ← hand-maintained — SpaceGassApiClient : BaseSpaceGassApiClient
@@ -86,6 +87,7 @@ When a new endpoint is similarly awkward (multipart uploads, list-string filters
 ```
 sdks/python/client/
 ├── pyproject.toml
+├── tests/                          ← pytest suite; wire-level via httpx.MockTransport (`python -m pytest`, deps: `pip install -e ".[dev]"`)
 └── space_gass_api/
     ├── __init__.py                 ← AUTO-WRITTEN post-Kiota by tools/regen_python_inits.py
     ├── __init__.pyi                ← AUTO-WRITTEN post-Kiota (type stub for IDE support)
@@ -144,6 +146,7 @@ sdks/python/client/
 | `deploy-docs.yml` | Push to `main` | Build Zudoku site and deploy to GitHub Pages |
 | `generate-clients.yml` | Manual (`workflow_dispatch`) | Run Kiota to regenerate SDK clients |
 | `publish-packages.yml` | GitHub Release published | Publish to NuGet and PyPI |
+| `test-clients.yml` | Push to `main`, PRs | Run C# (xUnit) and Python (pytest) client test suites |
 
 ### Versioning
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # SPACE GASS API
 
+[![Tests](https://github.com/SpaceGass/space-gass-api/actions/workflows/test-clients.yml/badge.svg)](https://github.com/SpaceGass/space-gass-api/actions/workflows/test-clients.yml)
+[![NuGet](https://img.shields.io/nuget/v/SpaceGassApi?logo=nuget&label=NuGet)](https://www.nuget.org/packages/SpaceGassApi)
+[![PyPI](https://img.shields.io/pypi/v/space-gass-api?logo=pypi&logoColor=white&label=PyPI)](https://pypi.org/project/space-gass-api/)
+[![Docs](https://img.shields.io/badge/docs-api.spacegass.com-blue)](https://api.spacegass.com/docs/)
+[![License: MIT](https://img.shields.io/badge/license-MIT-green)](LICENSE)
+
 Official SPACE GASS API specifications, developer SDKs, and automation examples.
 
 **Developer docs:** [api.spacegass.com/docs](https://api.spacegass.com/docs/)\

--- a/sdks/csharp/client/SpaceGassApi.Tests/ListUtilsExtensionsTests.cs
+++ b/sdks/csharp/client/SpaceGassApi.Tests/ListUtilsExtensionsTests.cs
@@ -1,0 +1,65 @@
+using SpaceGassApi.Utils;
+using Xunit;
+
+namespace SpaceGassApi.Tests;
+
+public class ListUtilsExtensionsTests
+{
+    [Theory]
+    [InlineData(new[] { 1, 2, 3, 4, 5 }, "1-5")]
+    [InlineData(new[] { 1, 2 }, "1,2")]
+    [InlineData(new[] { 5, 3, 1, 4, 2 }, "1-5")]
+    [InlineData(new[] { 1, 3, 4, 5, 8, 10 }, "1,3-5,8,10")]
+    [InlineData(new[] { 7, 7, 7 }, "7")]
+    [InlineData(new[] { -3, 0, 2 }, "2")]
+    public void ToFilterString_FormatsSortedDedupedRuns(int[] ids, string expected)
+        => Assert.Equal(expected, ids.ToFilterString());
+
+    [Fact]
+    public void ToFilterString_TwoConsecutive_StaysExplicitPair()
+        => Assert.Equal("3,4", new[] { 4, 3 }.ToFilterString());
+
+    [Fact]
+    public void ToFilterString_EmptyInput_ReturnsEmpty()
+        => Assert.Equal(string.Empty, Array.Empty<int>().ToFilterString());
+
+    [Fact]
+    public void ToFilterString_NullInput_ReturnsEmpty()
+        => Assert.Equal(string.Empty, ((IEnumerable<int>)null!).ToFilterString());
+
+    [Fact]
+    public void ToFilterString_AllNonPositive_ReturnsEmpty()
+        => Assert.Equal(string.Empty, new[] { -1, 0 }.ToFilterString());
+
+    [Theory]
+    [InlineData("1-5", new[] { 1, 2, 3, 4, 5 })]
+    [InlineData("1,3-5,8", new[] { 1, 3, 4, 5, 8 })]
+    [InlineData("7-3", new[] { 3, 4, 5, 6, 7 })]
+    [InlineData(" 1 , 2 - 4 ", new[] { 1, 2, 3, 4 })]
+    [InlineData("5,1,5", new[] { 1, 5 })]
+    [InlineData("", new int[0])]
+    [InlineData("   ", new int[0])]
+    public void ToIdArray_ParsesRangesAndSingles(string filter, int[] expected)
+        => Assert.Equal(expected, filter.ToIdArray());
+
+    [Theory]
+    [InlineData("all")]
+    [InlineData("ALL")]
+    [InlineData("1,x")]
+    [InlineData("1-b")]
+    [InlineData("0")]
+    [InlineData("-5")]
+    public void ToIdArray_InvalidInput_ThrowsFormatException(string filter)
+        => Assert.Throws<FormatException>(() => filter.ToIdArray());
+
+    [Fact]
+    public void ToIdList_MatchesToIdArray()
+        => Assert.Equal(new List<int> { 1, 2, 3 }, "1-3".ToIdList());
+
+    [Fact]
+    public void FilterString_RoundTrips()
+    {
+        var ids = new[] { 1, 2, 3, 7, 9, 10, 11, 12, 40 };
+        Assert.Equal(ids, ids.ToFilterString().ToIdArray());
+    }
+}

--- a/sdks/csharp/client/SpaceGassApi.Tests/SpaceGassApi.Tests.csproj
+++ b/sdks/csharp/client/SpaceGassApi.Tests/SpaceGassApi.Tests.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" PrivateAssets="all" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\SpaceGassApi\SpaceGassApi.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/sdks/csharp/client/SpaceGassApi.Tests/SpaceGassApiClientTests.cs
+++ b/sdks/csharp/client/SpaceGassApi.Tests/SpaceGassApiClientTests.cs
@@ -1,0 +1,30 @@
+using System.Reflection;
+using Microsoft.Kiota.Abstractions;
+using Xunit;
+
+namespace SpaceGassApi.Tests;
+
+public class SpaceGassApiClientTests
+{
+    [Fact]
+    public void CreateClient_Default_AppendsApiPathToLocalhost()
+        => Assert.Equal("http://localhost:34560/api/v1", BaseUrlOf(SpaceGassApiClient.CreateClient()));
+
+    [Fact]
+    public void CreateClient_CustomBaseUrl_TrimsTrailingSlash()
+        => Assert.Equal(
+            "https://localhost:53484/api/v1",
+            BaseUrlOf(SpaceGassApiClient.CreateClient("https://localhost:53484/")));
+
+    private static string BaseUrlOf(SpaceGassApiClient client)
+    {
+        // RequestAdapter sits on Kiota's BaseRequestBuilder; visibility has
+        // changed between Kiota versions, so resolve it reflectively.
+        var property = typeof(BaseRequestBuilder).GetProperty(
+            "RequestAdapter",
+            BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+        Assert.NotNull(property);
+        var adapter = (IRequestAdapter)property!.GetValue(client)!;
+        return adapter.BaseUrl!;
+    }
+}

--- a/sdks/csharp/client/SpaceGassApi.Tests/Support/CapturingHandler.cs
+++ b/sdks/csharp/client/SpaceGassApi.Tests/Support/CapturingHandler.cs
@@ -1,0 +1,62 @@
+using System.Net;
+using System.Text;
+using Microsoft.Kiota.Abstractions.Authentication;
+using Microsoft.Kiota.Http.HttpClientLibrary;
+
+namespace SpaceGassApi.Tests.Support;
+
+/// <summary>
+/// Test double standing in for the SPACE GASS service: records every outgoing
+/// request and answers with canned JSON, so tests can assert what actually
+/// goes on the wire without a live service.
+/// </summary>
+public sealed class CapturingHandler : HttpMessageHandler
+{
+    public sealed record CapturedRequest(HttpMethod Method, Uri Uri, string? ContentType, byte[] Body)
+    {
+        public string BodyText => Encoding.UTF8.GetString(Body);
+    }
+
+    private readonly Func<HttpRequestMessage, HttpResponseMessage> _respond;
+
+    public CapturingHandler(Func<HttpRequestMessage, HttpResponseMessage>? respond = null)
+        => _respond = respond ?? (_ => Json("{}"));
+
+    public List<CapturedRequest> Requests { get; } = [];
+
+    public CapturedRequest Last => Requests[^1];
+
+    protected override async Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        var body = request.Content is null
+            ? Array.Empty<byte>()
+            : await request.Content.ReadAsByteArrayAsync(cancellationToken);
+        Requests.Add(new CapturedRequest(
+            request.Method,
+            request.RequestUri!,
+            request.Content?.Headers.ContentType?.ToString(),
+            body));
+        return _respond(request);
+    }
+
+    public static HttpResponseMessage Json(string json, HttpStatusCode status = HttpStatusCode.OK)
+        => new(status) { Content = new StringContent(json, Encoding.UTF8, "application/json") };
+
+    /// <summary>
+    /// A <see cref="SpaceGassApiClient"/> whose HTTP traffic is captured by the
+    /// returned handler instead of hitting the network.
+    /// </summary>
+    public static (SpaceGassApiClient Client, CapturingHandler Handler) CreateMockedClient(
+        Func<HttpRequestMessage, HttpResponseMessage>? respond = null)
+    {
+        var handler = new CapturingHandler(respond);
+        var adapter = new HttpClientRequestAdapter(
+            new AnonymousAuthenticationProvider(),
+            httpClient: new HttpClient(handler))
+        {
+            BaseUrl = "http://localhost:34560/api/v1",
+        };
+        return (new SpaceGassApiClient(adapter), handler);
+    }
+}

--- a/sdks/csharp/client/SpaceGassApi.Tests/UploadRequestsTests.cs
+++ b/sdks/csharp/client/SpaceGassApi.Tests/UploadRequestsTests.cs
@@ -1,0 +1,66 @@
+using SpaceGassApi.Tests.Support;
+using Xunit;
+
+namespace SpaceGassApi.Tests;
+
+public class UploadRequestsTests
+{
+    [Fact]
+    public async Task NewFromTemplateRequest_UploadsFileAsTemplatePart()
+    {
+        var file = await WriteTempFileAsync("portal.sgbase", "template-bytes");
+        try
+        {
+            var (client, handler) = CapturingHandler.CreateMockedClient();
+
+            await client.Job.NewFromTemplate.PostAsync(new NewFromTemplateRequest(file));
+
+            Assert.Equal("/api/v1/job/new-from-template", handler.Last.Uri.AbsolutePath);
+            Assert.StartsWith("multipart/form-data", handler.Last.ContentType);
+            Assert.Contains("name=\"template\"", handler.Last.BodyText);
+            Assert.Contains("portal.sgbase", handler.Last.BodyText);
+            Assert.Contains("template-bytes", handler.Last.BodyText);
+        }
+        finally
+        {
+            File.Delete(file);
+        }
+    }
+
+    [Fact]
+    public async Task ImportTxtRequest_UploadsFileAsFilePart()
+    {
+        var file = await WriteTempFileAsync("model.txt", "import-me");
+        try
+        {
+            var (client, handler) = CapturingHandler.CreateMockedClient();
+
+            await client.Job.Import.Txt.PostAsync(new ImportTxtRequest(file));
+
+            Assert.Equal("/api/v1/job/import/txt", handler.Last.Uri.AbsolutePath);
+            Assert.StartsWith("multipart/form-data", handler.Last.ContentType);
+            Assert.Contains("name=\"file\"", handler.Last.BodyText);
+            Assert.Contains("model.txt", handler.Last.BodyText);
+        }
+        finally
+        {
+            File.Delete(file);
+        }
+    }
+
+    [Fact]
+    public void MissingFile_ThrowsFileNotFound()
+    {
+        var missing = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName(), "missing.sgbase");
+        Assert.Throws<FileNotFoundException>(() => new NewFromTemplateRequest(missing));
+        Assert.Throws<FileNotFoundException>(() => new ImportTxtRequest(missing));
+    }
+
+    private static async Task<string> WriteTempFileAsync(string name, string content)
+    {
+        var dir = Directory.CreateTempSubdirectory("sg-tests-").FullName;
+        var path = Path.Combine(dir, name);
+        await File.WriteAllTextAsync(path, content);
+        return path;
+    }
+}

--- a/sdks/csharp/client/SpaceGassApi.Tests/WireTests.cs
+++ b/sdks/csharp/client/SpaceGassApi.Tests/WireTests.cs
@@ -1,0 +1,92 @@
+using System.Net;
+using System.Text.Json;
+using SpaceGassApi.Models;
+using SpaceGassApi.Tests.Support;
+using Xunit;
+
+namespace SpaceGassApi.Tests;
+
+/// <summary>
+/// Asserts what actually goes on the wire — URLs, query strings, verbs,
+/// serialized bodies — and how error responses map back to typed exceptions.
+/// </summary>
+public class WireTests
+{
+    [Fact]
+    public async Task Get_WithoutConfiguration_HasNoQueryString()
+    {
+        var (client, handler) = CapturingHandler.CreateMockedClient(_ => CapturingHandler.Json("[]"));
+
+        await client.Job.Structure.Nodes.GetAsync();
+
+        Assert.Equal(HttpMethod.Get, handler.Last.Method);
+        Assert.Equal(string.Empty, handler.Last.Uri.Query);
+        Assert.Equal("/api/v1/job/structure/nodes", handler.Last.Uri.AbsolutePath);
+    }
+
+    [Fact]
+    public async Task Get_WithQueryParameters_PutsThemInTheUrl()
+    {
+        var (client, handler) = CapturingHandler.CreateMockedClient(_ => CapturingHandler.Json("[]"));
+
+        await client.Job.Structure.Nodes.GetAsync(c =>
+            c.QueryParameters.NodeTypeAsNodeTypeFilter = NodeTypeFilter.Restrained);
+
+        Assert.Contains("nodeType=Restrained", handler.Last.Uri.Query);
+    }
+
+    [Fact]
+    public async Task BulkPost_WithContinueOnError_AddsQueryParameterAndSerializesBody()
+    {
+        var (client, handler) = CapturingHandler.CreateMockedClient();
+        var body = new List<NodeCreate> { new() { X = 1.5, Y = 2.0, Z = 3.0 } };
+
+        await client.Job.Structure.Nodes.Bulk.PostAsync(body, c =>
+            c.QueryParameters.ContinueOnError = true);
+
+        Assert.Equal(HttpMethod.Post, handler.Last.Method);
+        Assert.Contains("continueOnError=true", handler.Last.Uri.Query);
+
+        using var json = JsonDocument.Parse(handler.Last.BodyText);
+        Assert.Equal(1.5, json.RootElement[0].GetProperty("x").GetDouble());
+    }
+
+    [Fact]
+    public async Task BulkDelete_SendsIdListBody()
+    {
+        var (client, handler) = CapturingHandler.CreateMockedClient();
+
+        await client.Job.Structure.Nodes.Bulk.DeleteAsync([1, 2, 3]);
+
+        Assert.Equal(HttpMethod.Delete, handler.Last.Method);
+        using var json = JsonDocument.Parse(handler.Last.BodyText);
+        Assert.Equal(3, json.RootElement.GetArrayLength());
+    }
+
+    [Fact]
+    public async Task Post_SerializesRequestBodyProperties()
+    {
+        var (client, handler) = CapturingHandler.CreateMockedClient();
+
+        await client.Job.Open.PostAsync(new OpenJobRequest { FilePath = @"C:\Projects\MyStructure.sg" });
+
+        Assert.Equal("/api/v1/job/open", handler.Last.Uri.AbsolutePath);
+        using var json = JsonDocument.Parse(handler.Last.BodyText);
+        Assert.Equal(@"C:\Projects\MyStructure.sg", json.RootElement.GetProperty("filePath").GetString());
+    }
+
+    [Fact]
+    public async Task ErrorBody_SurfacesAsTypedErrorResponseException()
+    {
+        var (client, _) = CapturingHandler.CreateMockedClient(_ => CapturingHandler.Json(
+            """{"title":"Not Found","status":404,"detail":"Node 999 not found","errorCode":"NOT_FOUND"}""",
+            HttpStatusCode.NotFound));
+
+        var err = await Assert.ThrowsAsync<ErrorResponse>(
+            () => client.Job.Structure.Nodes[999].GetAsync());
+
+        Assert.Equal(404, err.Status);
+        Assert.Equal("Node 999 not found", err.Detail);
+        Assert.Equal("NOT_FOUND", err.ErrorCode);
+    }
+}

--- a/sdks/csharp/client/SpaceGassApi.sln
+++ b/sdks/csharp/client/SpaceGassApi.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 17.0.31903.59
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SpaceGassApi", "SpaceGassApi\SpaceGassApi.csproj", "{77C42EA6-B543-442D-8F97-A11FAE3E9515}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SpaceGassApi.Tests", "SpaceGassApi.Tests\SpaceGassApi.Tests.csproj", "{2048FF68-F97E-4804-BBA2-C7E5F075A9DC}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -27,6 +29,18 @@ Global
 		{77C42EA6-B543-442D-8F97-A11FAE3E9515}.Release|x64.Build.0 = Release|Any CPU
 		{77C42EA6-B543-442D-8F97-A11FAE3E9515}.Release|x86.ActiveCfg = Release|Any CPU
 		{77C42EA6-B543-442D-8F97-A11FAE3E9515}.Release|x86.Build.0 = Release|Any CPU
+		{2048FF68-F97E-4804-BBA2-C7E5F075A9DC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2048FF68-F97E-4804-BBA2-C7E5F075A9DC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2048FF68-F97E-4804-BBA2-C7E5F075A9DC}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{2048FF68-F97E-4804-BBA2-C7E5F075A9DC}.Debug|x64.Build.0 = Debug|Any CPU
+		{2048FF68-F97E-4804-BBA2-C7E5F075A9DC}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{2048FF68-F97E-4804-BBA2-C7E5F075A9DC}.Debug|x86.Build.0 = Debug|Any CPU
+		{2048FF68-F97E-4804-BBA2-C7E5F075A9DC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2048FF68-F97E-4804-BBA2-C7E5F075A9DC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2048FF68-F97E-4804-BBA2-C7E5F075A9DC}.Release|x64.ActiveCfg = Release|Any CPU
+		{2048FF68-F97E-4804-BBA2-C7E5F075A9DC}.Release|x64.Build.0 = Release|Any CPU
+		{2048FF68-F97E-4804-BBA2-C7E5F075A9DC}.Release|x86.ActiveCfg = Release|Any CPU
+		{2048FF68-F97E-4804-BBA2-C7E5F075A9DC}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/sdks/python/client/pyproject.toml
+++ b/sdks/python/client/pyproject.toml
@@ -23,10 +23,26 @@ dependencies = [
     "microsoft-kiota-bundle>=1.9.8",
 ]
 
+[project.optional-dependencies]
+dev = [
+    "pytest>=8",
+    "pytest-asyncio>=0.24",
+]
+
 [project.urls]
 Documentation = "https://api.spacegass.com/docs/"
 Repository = "https://github.com/SpaceGass/space-gass-api"
 Issues = "https://github.com/SpaceGass/space-gass-api/issues"
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+testpaths = ["tests"]
+filterwarnings = [
+    # Kiota's generated code and abstractions carry their own deprecation
+    # notices for legacy request-configuration classes — not actionable here.
+    "ignore:This class is deprecated:DeprecationWarning",
+    "ignore:GetQueryParameters is deprecated:DeprecationWarning",
+]
 
 [tool.setuptools.packages.find]
 include = ["space_gass_api*"]

--- a/sdks/python/client/tests/conftest.py
+++ b/sdks/python/client/tests/conftest.py
@@ -1,0 +1,67 @@
+"""Shared fixtures: a ``SpaceGassApiClient`` wired to ``httpx.MockTransport``.
+
+The transport records every outgoing request and answers with canned JSON,
+so tests can assert what actually goes on the wire — URLs, query strings,
+verbs, serialized bodies — without a live SPACE GASS service.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Allow running straight from the repo without installing the package.
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import httpx
+import pytest
+from kiota_abstractions.authentication import AnonymousAuthenticationProvider
+from kiota_http.httpx_request_adapter import HttpxRequestAdapter
+
+from space_gass_api import SpaceGassApiClient
+
+
+class RecordedRequests:
+    def __init__(self) -> None:
+        self.requests: list[httpx.Request] = []
+
+    @property
+    def last(self) -> httpx.Request:
+        return self.requests[-1]
+
+    @property
+    def last_body(self) -> str:
+        return self.last.content.decode()
+
+
+@pytest.fixture
+def recorded() -> RecordedRequests:
+    return RecordedRequests()
+
+
+@pytest.fixture
+def make_client(recorded):
+    """Factory for a client with a custom response handler."""
+
+    def factory(respond=None) -> SpaceGassApiClient:
+        def handler(request: httpx.Request) -> httpx.Response:
+            recorded.requests.append(request)
+            if respond is not None:
+                return respond(request)
+            if request.method == "GET" and request.url.path.endswith("/structure/nodes"):
+                return httpx.Response(200, json=[])
+            return httpx.Response(200, json={})
+
+        adapter = HttpxRequestAdapter(
+            AnonymousAuthenticationProvider(),
+            http_client=httpx.AsyncClient(transport=httpx.MockTransport(handler)),
+        )
+        adapter.base_url = "http://localhost:34560/api/v1"
+        return SpaceGassApiClient(adapter)
+
+    return factory
+
+
+@pytest.fixture
+def client(make_client) -> SpaceGassApiClient:
+    return make_client()

--- a/sdks/python/client/tests/test_create_client.py
+++ b/sdks/python/client/tests/test_create_client.py
@@ -1,0 +1,11 @@
+from space_gass_api import SpaceGassApiClient
+
+
+def test_default_base_url_appends_api_path():
+    client = SpaceGassApiClient.create_client()
+    assert client.request_adapter.base_url == "http://localhost:34560/api/v1"
+
+
+def test_custom_base_url_trims_trailing_slash():
+    client = SpaceGassApiClient.create_client("https://localhost:53484/")
+    assert client.request_adapter.base_url == "https://localhost:53484/api/v1"

--- a/sdks/python/client/tests/test_kwargs_query_params.py
+++ b/sdks/python/client/tests/test_kwargs_query_params.py
@@ -1,0 +1,103 @@
+"""The kwargs query-parameter enhancement on get/post/patch/delete.
+
+Every builder verb with a matching ``{Verb}QueryParameters`` dataclass
+accepts those parameters as keyword arguments (see
+``_enhance_request_methods`` in ``space_gass_api_client.py``).
+"""
+
+import pytest
+from kiota_abstractions.base_request_configuration import RequestConfiguration
+
+import space_gass_api.models as models
+
+
+async def test_get_kwargs_add_query_param(client, recorded):
+    await client.job.structure.nodes.get(node_type=models.NodeTypeFilter.Restrained)
+
+    assert recorded.last.method == "GET"
+    assert "nodeType=" in str(recorded.last.url)
+
+
+async def test_bulk_post_kwargs_add_query_param(client, recorded):
+    await client.job.structure.nodes.bulk.post(
+        [models.NodeCreate(x=1.5)], continue_on_error=True
+    )
+
+    assert recorded.last.method == "POST"
+    assert "continueOnError=true" in str(recorded.last.url)
+    assert '"x": 1.5' in recorded.last_body
+
+
+async def test_bulk_post_plain_call_has_no_query_string(client, recorded):
+    await client.job.structure.nodes.bulk.post([models.NodeCreate(x=1.0)])
+
+    assert recorded.last.url.query == b""
+
+
+async def test_bulk_post_body_as_keyword_still_routes_to_body(client, recorded):
+    await client.job.structure.nodes.bulk.post(
+        body=[models.NodeCreate(x=9.0)], continue_on_error=True
+    )
+
+    assert '"x": 9.0' in recorded.last_body
+    assert "continueOnError=true" in str(recorded.last.url)
+
+
+async def test_bulk_patch_kwargs_add_query_param(client, recorded):
+    await client.job.structure.nodes.bulk.patch(
+        [models.NodeUpdate(id=1)], continue_on_error=True
+    )
+
+    assert recorded.last.method == "PATCH"
+    assert "continueOnError=true" in str(recorded.last.url)
+
+
+async def test_bulk_delete_kwargs_add_query_param(client, recorded):
+    await client.job.structure.nodes.bulk.delete([1, 2, 3], continue_on_error=True)
+
+    assert recorded.last.method == "DELETE"
+    assert "continueOnError=true" in str(recorded.last.url)
+    assert recorded.last_body.replace(" ", "") == "[1,2,3]"
+
+
+async def test_bodyless_delete_kwargs_add_query_param(client, recorded):
+    await client.job.data.delete(force=True)
+
+    assert recorded.last.method == "DELETE"
+    assert "force=true" in str(recorded.last.url)
+
+
+async def test_request_configuration_path_still_works(client, recorded):
+    bulk = client.job.structure.nodes.bulk
+    qp = type(bulk).BulkRequestBuilderPostQueryParameters(continue_on_error=True)
+
+    await bulk.post(
+        [models.NodeCreate(x=1.0)],
+        request_configuration=RequestConfiguration(query_parameters=qp),
+    )
+
+    assert "continueOnError=true" in str(recorded.last.url)
+
+
+async def test_unknown_kwarg_raises_type_error(client):
+    with pytest.raises(TypeError):
+        await client.job.structure.nodes.bulk.post(
+            [models.NodeCreate(x=1.0)], not_a_param=True
+        )
+
+
+async def test_request_configuration_plus_kwargs_raises_type_error(client):
+    bulk = client.job.structure.nodes.bulk
+    qp = type(bulk).BulkRequestBuilderPostQueryParameters(continue_on_error=True)
+
+    with pytest.raises(TypeError, match="Cannot pass both"):
+        await bulk.post(
+            [models.NodeCreate(x=1.0)],
+            request_configuration=RequestConfiguration(query_parameters=qp),
+            continue_on_error=True,
+        )
+
+
+async def test_missing_body_raises_type_error(client):
+    with pytest.raises(TypeError):
+        await client.job.structure.nodes.bulk.post(continue_on_error=True)

--- a/sdks/python/client/tests/test_models_shim.py
+++ b/sdks/python/client/tests/test_models_shim.py
@@ -1,0 +1,61 @@
+"""The ``space_gass_api.models`` re-export shim (written post-Kiota by
+``tools/regen_python_inits.py``)."""
+
+import importlib
+
+import pytest
+from kiota_abstractions.api_error import APIError
+
+
+def test_documented_model_imports_resolve():
+    from space_gass_api.models import (  # noqa: F401
+        ErrorResponse,
+        NodeCreate,
+        OpenJobRequest,
+        OpenSampleRequest,
+        SaveJobRequest,
+    )
+
+
+def test_error_response_is_catchable_api_error():
+    from space_gass_api.models import ErrorResponse
+
+    assert issubclass(ErrorResponse, APIError)
+
+
+def test_models_module_attribute_access():
+    import space_gass_api.models as models
+
+    assert models.NodeCreate(x=1.0).x == 1.0
+
+
+def test_models_submodule_imports_do_not_exist():
+    # Regression for a docs bug: models is a flat re-export shim, so
+    # `space_gass_api.models.error_response` must not be documented or used.
+    with pytest.raises(ModuleNotFoundError):
+        importlib.import_module("space_gass_api.models.error_response")
+
+
+async def test_error_body_surfaces_as_typed_exception(make_client):
+    import httpx
+
+    from space_gass_api.models import ErrorResponse
+
+    client = make_client(
+        lambda request: httpx.Response(
+            404,
+            json={
+                "title": "Not Found",
+                "status": 404,
+                "detail": "Node 999 not found",
+                "errorCode": "NOT_FOUND",
+            },
+        )
+    )
+
+    with pytest.raises(ErrorResponse) as excinfo:
+        await client.job.structure.nodes.by_id(999).get()
+
+    assert excinfo.value.status == 404
+    assert excinfo.value.detail == "Node 999 not found"
+    assert excinfo.value.error_code == "NOT_FOUND"

--- a/sdks/python/client/tests/test_upload_requests.py
+++ b/sdks/python/client/tests/test_upload_requests.py
@@ -1,0 +1,36 @@
+import pytest
+
+from space_gass_api import ImportTxtRequest, NewFromTemplateRequest
+
+
+async def test_new_from_template_uploads_multipart_template_part(client, recorded, tmp_path):
+    template = tmp_path / "portal.sgbase"
+    template.write_bytes(b"template-bytes")
+
+    await client.job.new_from_template.post(NewFromTemplateRequest(str(template)))
+
+    assert recorded.last.url.path.endswith("/job/new-from-template")
+    assert recorded.last.headers["content-type"].startswith("multipart/form-data")
+    assert b'name="template"' in recorded.last.content
+    assert b"portal.sgbase" in recorded.last.content
+    assert b"template-bytes" in recorded.last.content
+
+
+async def test_import_txt_uploads_multipart_file_part(client, recorded, tmp_path):
+    txt = tmp_path / "model.txt"
+    txt.write_text("import-me")
+
+    await client.job.import_.txt.post(ImportTxtRequest(str(txt)))
+
+    assert recorded.last.url.path.endswith("/job/import/txt")
+    assert recorded.last.headers["content-type"].startswith("multipart/form-data")
+    assert b'name="file"' in recorded.last.content
+    assert b"model.txt" in recorded.last.content
+
+
+def test_missing_file_raises(tmp_path):
+    missing = str(tmp_path / "missing.sgbase")
+    with pytest.raises(FileNotFoundError):
+        NewFromTemplateRequest(missing)
+    with pytest.raises(FileNotFoundError):
+        ImportTxtRequest(missing)


### PR DESCRIPTION
## Summary

Adds test projects for both SDK clients, a CI workflow that runs them, and a badge row on the README.

> **Stacked on #68** — the Python suite exercises the all-verbs kwargs enhancement from that PR. Merge #68 first; GitHub will retarget this PR to `main` when the `small_docs_fix` branch is deleted.

### C# — `SpaceGassApi.Tests` (36 tests, xUnit, net10.0)

Covers the hand-maintained layer on top of Kiota, with all HTTP captured in-process by a `CapturingHandler` (no live service):

- `ListUtilsExtensions` — SG list-string round-trips, run collapsing, dedupe/sort, `FormatException` on invalid input
- `CreateClient` — base URL composition (default, custom, trailing slash)
- Wire tests — query params land in URLs, bodies serialize correctly, and a 404 JSON body surfaces as the typed `ErrorResponse` exception (exactly what the error-handling docs promise)
- `NewFromTemplateRequest` / `ImportTxtRequest` — multipart/form-data with the right part name, filename and bytes

### Python — `tests/` under the client (21 tests, pytest + httpx.MockTransport)

- kwargs query params on `get`/`post`/`patch`/`delete` (incl. body-less delete, the `request_configuration` escape hatch, and `TypeError` on misuse)
- `create_client` base URL composition
- models shim: documented imports resolve, `ErrorResponse` is a catchable `APIError`, and `space_gass_api.models.<submodule>` imports stay nonexistent — a permanent regression guard for the docs bug that started #68
- multipart upload helpers

Dev deps are the `dev` extra: `pip install -e ".[dev]"`, then `python -m pytest` from `sdks/python/client/`.

### CI + badges

- `.github/workflows/test-clients.yml` (**Tests**) runs both suites on ubuntu-latest for pushes to `main` and all PRs — so this PR itself is the workflow's first live run
- README badge row: Tests status (native Actions badge), NuGet + PyPI versions (shields.io live-queries the registries), docs link, MIT license

## Verification

- `dotnet test SpaceGassApi.sln` — 36/36 passing locally
- `python -m pytest` — 21/21 passing locally, zero warnings (Kiota's own deprecation notices filtered in pytest config)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
