### PR TITLE
Add net10.0 target to the client SDK

### DIFF
--- a/sdks/csharp/client/SpaceGassApi/SpaceGassApi.csproj
+++ b/sdks/csharp/client/SpaceGassApi/SpaceGassApi.csproj
@@ -1,12 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net10.0</TargetFrameworks>
     <RootNamespace>SpaceGassApi</RootNamespace>
-    <!-- SpaceGassApi.Client.dll: SPACE GASS itself ships a server-side
-         SpaceGassAPI.dll, which would collide with this assembly's default
-         name on a case-insensitive filesystem. Namespaces and the package id
-         stay SpaceGassApi. -->
     <AssemblyName>SpaceGassApi.Client</AssemblyName>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>


### PR DESCRIPTION
net10.0 consumers get a first-class build instead of the netstandard2.1 fallback; the netstandard targets keep .NET Framework and older .NET consumers working. Package now ships lib/netstandard2.0, /netstandard2.1 and /net10.0.