### PR TITLE
Lift System.Text.Json above the vulnerable transitive 8.0.0

### DIFF
--- a/sdks/csharp/client/SpaceGassApi/SpaceGassApi.csproj
+++ b/sdks/csharp/client/SpaceGassApi/SpaceGassApi.csproj
@@ -24,6 +24,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Kiota.Bundle" Version="2.0.0" />
+    <!-- lifts Kiota.Bundle's vulnerable System.Text.Json 8.0.0 (NU1903) -->
+    <PackageReference Include="System.Text.Json" Version="8.0.6" />
   </ItemGroup>
 
   <!-- Include generated source files and the hand-maintained client -->


### PR DESCRIPTION
Microsoft.Kiota.Bundle 2.0.0 (current latest) references System.Text.Json 8.0.0, which carries two known high-severity advisories (GHSA-8g4q-xg66-9fp4, GHSA-hh2w-p6rv-4g7w) that every package consumer inherited via NU1903. A direct reference to 8.0.6 (latest 8.x patch) lifts the transitive version; net10 consumers are unaffected as the SDK prunes it in favour of the in-box copy.