### PR TITLE
Docs: mention the .NET 10 target

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@ import in [CLAUDE.md](CLAUDE.md).
 
 ```bash
 pip install space-gass-api          # Python 3.9+
-dotnet add package SpaceGassApi     # C# / .NET Standard 2.0+
+dotnet add package SpaceGassApi     # C# / .NET 10 or .NET Standard 2.0+
 ```
 
 ## Minimal usage

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This repository contains:
 
 ### Install the SDK
 
-**C# (.NET Standard 2.0+)**
+**C# (.NET 10 / .NET Standard 2.0+)**
 
 ```bash
 dotnet new console -n MyApp && cd MyApp

--- a/sdks/csharp/client/SpaceGassApi/README.md
+++ b/sdks/csharp/client/SpaceGassApi/README.md
@@ -10,7 +10,7 @@ The SPACE GASS API gives you programmatic access to SPACE GASS structural analys
 dotnet add package SpaceGassApi
 ```
 
-- Targets **.NET Standard 2.0** and **2.1** (.NET Framework 4.6.1+, .NET Core 2.0+, .NET 5/6/8+)
+- Targets **.NET 10** and **.NET Standard 2.0/2.1** (.NET Framework 4.6.1+, .NET Core 2.0+, .NET 5/6/8+)
 - [SPACE GASS](https://www.spacegass.com) **14.5 or later** installed with an active licence
 - The SPACE GASS API service running locally (default: `http://localhost:34560`)
 


### PR DESCRIPTION
The client SDK now ships a net10.0 build alongside the netstandard targets; the package README (shown on nuget.org), the repo README and AGENTS.md now say so.