### PR TITLE
Add NuGet / PyPI / GitHub release badges to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # SPACE GASS API
 
+[![NuGet](https://img.shields.io/nuget/v/SpaceGassApi?label=NuGet&logo=nuget)](https://www.nuget.org/packages/SpaceGassApi)
+[![PyPI](https://img.shields.io/pypi/v/space-gass-api?label=PyPI&logo=pypi)](https://pypi.org/project/space-gass-api/)
+[![GitHub release](https://img.shields.io/github/v/release/SpaceGass/space-gass-api?label=Release&logo=github)](https://github.com/SpaceGass/space-gass-api/releases)
+
 Official SPACE GASS API specifications, developer SDKs, and automation examples.
 
 **Developer docs:** [api.spacegass.com/docs](https://api.spacegass.com/docs/)\


### PR DESCRIPTION
Latest published version on each surface, linked to the respective registry page, so version skew between the feeds and the releases is visible at a glance.