### PR TITLE
Release badge: include pre-releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 [![NuGet](https://img.shields.io/nuget/v/SpaceGassApi?label=NuGet&logo=nuget)](https://www.nuget.org/packages/SpaceGassApi)
 [![PyPI](https://img.shields.io/pypi/v/space-gass-api?label=PyPI&logo=pypi)](https://pypi.org/project/space-gass-api/)
-[![GitHub release](https://img.shields.io/github/v/release/SpaceGass/space-gass-api?include_prereleases&label=Release&logo=github)](https://github.com/SpaceGass/space-gass-api/releases)
+[![GitHub release](https://img.shields.io/github/v/release/SpaceGass/space-gass-api?label=Release&logo=github)](https://github.com/SpaceGass/space-gass-api/releases)
+[![GitHub pre-release](https://img.shields.io/github/v/release/SpaceGass/space-gass-api?include_prereleases&label=Release&logo=github)](https://github.com/SpaceGass/space-gass-api/releases)
 
 Official SPACE GASS API specifications, developer SDKs, and automation examples.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![NuGet](https://img.shields.io/nuget/v/SpaceGassApi?label=NuGet&logo=nuget)](https://www.nuget.org/packages/SpaceGassApi)
 [![PyPI](https://img.shields.io/pypi/v/space-gass-api?label=PyPI&logo=pypi)](https://pypi.org/project/space-gass-api/)
-[![GitHub release](https://img.shields.io/github/v/release/SpaceGass/space-gass-api?label=Release&logo=github)](https://github.com/SpaceGass/space-gass-api/releases)
+[![GitHub release](https://img.shields.io/github/v/release/SpaceGass/space-gass-api?include_prereleases&label=Release&logo=github)](https://github.com/SpaceGass/space-gass-api/releases)
 
 Official SPACE GASS API specifications, developer SDKs, and automation examples.
 


### PR DESCRIPTION
Every release is currently flagged pre-release, so the plain badge renders as an error (it only counts stable releases). Tracking the newest release regardless of flag keeps it aligned with the NuGet and PyPI badges.