### PR TITLE
ci: only deploy docs when docs or the spec change

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -3,6 +3,18 @@ name: Deploy Documentation
 on:
   push:
     branches: [main]
+    # Only redeploy when something the site is built from changes. The build
+    # reads docs/** and descriptions/preview/openapi.json (imported by
+    # zudoku.config.tsx) and nothing else — sdks/** appears in the pages only
+    # as GitHub hyperlinks. descriptions/** must stay in this list: the
+    # BuildMachine SDK-regen pipeline (SPACEGASS generate-api-clients.yml)
+    # pushes the fresh spec to main and relies on this workflow to publish it.
+    paths:
+      - "docs/**"
+      - "descriptions/**"
+      - ".github/workflows/deploy-docs.yml"
+  # Manual escape hatch in case a deploy is ever needed without a matching push.
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

**Deploy Documentation** currently runs on every push to `main`, so dependency bumps and other unrelated PR merges rebuild and redeploy an identical docs site. This adds a `paths:` filter covering everything the site is built from, plus a `workflow_dispatch` trigger as a manual escape hatch (there was none).

The docs build reads exactly two inputs:
- `docs/**`
- `descriptions/preview/openapi.json` — imported by `zudoku.config.tsx` for the API reference and the "Preview (build X)" label

`sdks/**` appears in the pages only as GitHub hyperlinks, never as build inputs, so it is deliberately not in the filter.

## BuildMachine chain unaffected

The SPACEGASS BuildMachine pipeline (`generate-api-clients.yml`) pushes one atomic commit to `main` here after each release build, and that commit always rewrites `descriptions/preview/openapi.json` (every release stamps a new `info.x-space-gass-build`). That matches the filter, so the docs still redeploy with the fresh spec after every SDK regen. The rescue-PR path (`sdk-regen/*` merges) also touches `descriptions/` and stays covered. Nothing in the BuildMachine chain waits on this workflow, so a filtered-out run can't block anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)